### PR TITLE
Build CI on pull_request only.

### DIFF
--- a/.github/workflows/check_release.yml
+++ b/.github/workflows/check_release.yml
@@ -1,0 +1,172 @@
+name: Check Release
+
+on:
+  pull_request:
+    branches:
+      - "r/[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  check-version:
+    name: check-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get the release version from the branch
+        if: env.VERSION == ''
+        run: |
+          VERSION=${{ github.head_ref }}
+          VERSION=${VERSION##r/}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Show the version
+        run: |
+          echo "version is: $VERSION"
+      - name: Check that tag version and Cargo.toml version are the same
+        shell: bash
+        run: |
+          if ! grep -q "version = \"$VERSION\"" Cargo.toml; then
+            echo "version does not match Cargo.toml" >&2
+            exit 1
+          fi
+    outputs:
+      version: ${{ env.VERSION }}
+
+  check-release:
+    name: check-release
+    needs: ['check-version']
+    runs-on: ${{ matrix.os }}
+    env:
+      # Emit backtraces on panics.
+      RUST_BACKTRACE: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        tool: [arx, tar2arx, zip2arx]
+        build: [linux, macos, windows]
+        include:
+        - build: linux
+          os: ubuntu-latest
+        - build: macos
+          os: macos-latest
+        - build: windows
+          os: windows-latest
+
+    steps:
+    - name: Install dependencies
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        sudo apt-get install -y libfuse-dev
+
+    - name: Install dependencies
+      if: ${{ matrix.os == 'macos-latest'}}
+      run: |
+        brew install macfuse
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Build release binary
+      shell: bash
+      run: |
+        cargo build --verbose --release -p ${{ matrix.tool }}
+        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+          bin="target/release/${{ matrix.tool }}.exe"
+        else
+          bin="target/release/${{ matrix.tool }}"
+        fi
+        echo "BIN=$bin" >> $GITHUB_ENV
+
+    - name: Strip release binary (macos)
+      if: matrix.os == 'macos-latest'
+      shell: bash
+      run: strip "$BIN"
+
+    - name: Determine archive name
+      shell: bash
+      run: |
+        version="${{ needs.create-release.outputs.version }}"
+        echo "ARCHIVE=${{ matrix.tool }}-$version-${{ matrix.build }}" >> $GITHUB_ENV
+
+    - name: Creating directory for archive
+      shell: bash
+      run: |
+        mkdir -p "$ARCHIVE"/{complete,doc}
+        cp "$BIN" "$ARCHIVE"/
+        cp {README.md,LICENSE-MIT} "$ARCHIVE"/
+        cp Changelog.md "$ARCHIVE"/doc/
+
+    - name: Generate completions
+      shell: bash
+      run: |
+        "$BIN" --version
+        "$BIN" --generate-complete=bash > "$ARCHIVE/complete/${{ matrix.tool }}.bash"
+        "$BIN" --generate-complete=fish > "$ARCHIVE/complete/${{ matrix.tool }}.fish"
+        "$BIN" --generate-complete=powershell > "$ARCHIVE/complete/_${{ matrix.tool }}.ps1"
+        "$BIN" --generate-complete=zsh > "$ARCHIVE/complete/_${{ matrix.tool }}"
+
+    - name: Generate man page
+      shell: bash
+      if: matrix.tool != 'arx'
+      run: |
+        "$BIN" --generate-man-page > "$ARCHIVE/doc/${{ matrix.tool }}.1"
+
+    - name: Generate man page (arx)
+      shell: bash
+      if: matrix.tool == 'arx'
+      run: |
+        "$BIN" --generate-man-page > "$ARCHIVE/doc/${{ matrix.tool }}.1"
+        commands="create list dump extract"
+        if [[ "${{ matrix.build }}" != "windows" ]]; then
+          commands=$commands" mount"
+        fi
+        for command in $commands
+        do
+          "$BIN" --generate-man-page=$command > "$ARCHIVE/doc/${{ matrix.tool }}-$command.1"
+        done
+
+    - name: Build archive (Windows)
+      shell: bash
+      if: matrix.os == 'windows-latest'
+      run: |
+        7z a "$ARCHIVE.zip" "$ARCHIVE"
+        certutil -hashfile "$ARCHIVE.zip" SHA256 > "$ARCHIVE.zip.sha256"
+        echo "ASSET=$ARCHIVE.zip" >> $GITHUB_ENV
+        echo "ASSET_SUM=$ARCHIVE.zip.sha256" >> $GITHUB_ENV
+
+    - name: Build archive (Unix)
+      shell: bash
+      if: matrix.os != 'windows-latest'
+      run: |
+        tar czf "$ARCHIVE.tar.gz" "$ARCHIVE"
+        shasum -a 256 "$ARCHIVE.tar.gz" > "$ARCHIVE.tar.gz.sha256"
+        echo "ASSET=$ARCHIVE.tar.gz" >> $GITHUB_ENV
+        echo "ASSET_SUM=$ARCHIVE.tar.gz.sha256" >> $GITHUB_ENV
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: pre_release-${{ matrix.build }}-${{ matrix.tool }}
+        path: |
+          ${{ env.ASSET }}
+        compression-level: 0
+
+  check-publication:
+    name: Check cargo publication
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Test Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish --dry-run -p libarx
+          # Until cargo publish can publish serveral package in the same time,
+          # only libarx will work in `--dry-run` mode.
+          # See https://github.com/rust-lang/cargo/issues/1169
+          #cargo publish --dry-run -p arx
+          #cargo publish --dry-run -p tar2arx
+          #cargo publish --dry-run -p zip2arx

--- a/.github/workflows/check_release.yml
+++ b/.github/workflows/check_release.yml
@@ -3,7 +3,7 @@ name: Check Release
 on:
   pull_request:
     branches:
-      - "r/[0-9]+.[0-9]+.[0-9]+"
+      - "r/[0-9]+.[0-9]+.[0-9]+(-[0-9a-zA-Z]+)?"
 
 jobs:
   check-version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: Cargo Build & Test
 
 on:
-  push:
   pull_request:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ env:
 jobs:
   build_and_test:
     name: Rust project - latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -20,7 +21,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-    runs-on: ${{ matrix.os }}
     steps:
       - name: Install dependencies
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -33,19 +33,22 @@ jobs:
           brew install macfuse
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Setup rust toolchain ${{ matrix.toolchain }}
-        run: |
-          rustup update ${{ matrix.toolchain }}
-          rustup default ${{ matrix.toolchain }}
-          rustup component add rustfmt
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: rustfmt
 
       - name: Check format
-        run: cargo fmt --check
+        run: cargo fmt --all --check
+
+      - name: Build
+        run: cargo build --workspace
 
       - name: Test code
-        run: cargo test --verbose --features in_ci
+        run: cargo test --workspace --verbose --features in_ci
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,17 @@ jobs:
 
       - name: Test code
         run: cargo test --verbose --features in_ci
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.os }}-${{ matrix.toolchain }}
+          path: |
+            target/debug/arx
+            target/debug/arx.exe
+            target/debug/tar2arx
+            target/debug/tar2arx.exe
+            target/debug/zip2arx
+            target/debug/zip2arx.exe
+            target/debug/auto_mount
+          compression-level: 0

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -1,11 +1,9 @@
 name: Pre-Release
 
-#
 on:
-  pull_request:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   contents: write
@@ -31,12 +29,12 @@ jobs:
         run: |
           if ! grep -q "version = \"$VERSION\"" Cargo.toml; then
             echo "version does not match Cargo.toml" >&2
-            #exit 1
+            exit 1
           fi
-#      - name: Create GitHub release
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: gh release create $VERSION --draft --verify-tag --title $VERSION
+      - name: Create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create $VERSION --draft --verify-tag --title $VERSION
     outputs:
       version: ${{ env.VERSION }}
 
@@ -162,12 +160,4 @@ jobs:
       shell: bash
       run: |
         version="${{ needs.create-release.outputs.version }}"
-      #  gh release upload "$version" ${{ env.ASSET }} ${{ env.ASSET_SUM }}
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: pre_release-${{ matrix.build }}-${{ matrix.tool }}
-        path: |
-          ${{ env.ASSET }}
-        compression-level: 0
+        gh release upload "$version" ${{ env.ASSET }} ${{ env.ASSET_SUM }}

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -1,0 +1,173 @@
+name: Pre-Release
+
+#
+on:
+  pull_request:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+
+jobs:
+  # The create-release job runs purely to initialize the GitHub release itself,
+  # and names the release after the `x.y.z` tag that was pushed. It's separate
+  # from building the release so that we only create the release once.
+  create-release:
+    name: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get the release version from the tag
+        if: env.VERSION == ''
+        run: echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+      - name: Show the version
+        run: |
+          echo "version is: $VERSION"
+      - name: Check that tag version and Cargo.toml version are the same
+        shell: bash
+        run: |
+          if ! grep -q "version = \"$VERSION\"" Cargo.toml; then
+            echo "version does not match Cargo.toml" >&2
+            #exit 1
+          fi
+#      - name: Create GitHub release
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: gh release create $VERSION --draft --verify-tag --title $VERSION
+    outputs:
+      version: ${{ env.VERSION }}
+
+  # Now the github release has been created, we can build our binaries
+  # and upload them to github release
+  build-release:
+    name: build-release
+    needs: ['create-release']
+    runs-on: ${{ matrix.os }}
+    env:
+      # Emit backtraces on panics.
+      RUST_BACKTRACE: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        tool: [arx, tar2arx, zip2arx]
+        build: [linux, macos, windows]
+        include:
+        - build: linux
+          os: ubuntu-latest
+        - build: macos
+          os: macos-latest
+        - build: windows
+          os: windows-latest
+
+    steps:
+    - name: Install dependencies
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        sudo apt-get install -y libfuse-dev
+
+    - name: Install dependencies
+      if: ${{ matrix.os == 'macos-latest'}}
+      run: |
+        brew install macfuse
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Build release binary
+      shell: bash
+      run: |
+        cargo build --verbose --release -p ${{ matrix.tool }}
+        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+          bin="target/release/${{ matrix.tool }}.exe"
+        else
+          bin="target/release/${{ matrix.tool }}"
+        fi
+        echo "BIN=$bin" >> $GITHUB_ENV
+
+    - name: Strip release binary (macos)
+      if: matrix.os == 'macos-latest'
+      shell: bash
+      run: strip "$BIN"
+
+    - name: Determine archive name
+      shell: bash
+      run: |
+        version="${{ needs.create-release.outputs.version }}"
+        echo "ARCHIVE=${{ matrix.tool }}-$version-${{ matrix.build }}" >> $GITHUB_ENV
+
+    - name: Creating directory for archive
+      shell: bash
+      run: |
+        mkdir -p "$ARCHIVE"/{complete,doc}
+        cp "$BIN" "$ARCHIVE"/
+        cp {README.md,LICENSE-MIT} "$ARCHIVE"/
+        cp Changelog.md "$ARCHIVE"/doc/
+
+    - name: Generate completions
+      shell: bash
+      run: |
+        "$BIN" --version
+        "$BIN" --generate-complete=bash > "$ARCHIVE/complete/${{ matrix.tool }}.bash"
+        "$BIN" --generate-complete=fish > "$ARCHIVE/complete/${{ matrix.tool }}.fish"
+        "$BIN" --generate-complete=powershell > "$ARCHIVE/complete/_${{ matrix.tool }}.ps1"
+        "$BIN" --generate-complete=zsh > "$ARCHIVE/complete/_${{ matrix.tool }}"
+
+    - name: Generate man page
+      shell: bash
+      if: matrix.tool != 'arx'
+      run: |
+        "$BIN" --generate-man-page > "$ARCHIVE/doc/${{ matrix.tool }}.1"
+
+    - name: Generate man page (arx)
+      shell: bash
+      if: matrix.tool == 'arx'
+      run: |
+        "$BIN" --generate-man-page > "$ARCHIVE/doc/${{ matrix.tool }}.1"
+        commands="create list dump extract"
+        if [[ "${{ matrix.build }}" != "windows" ]]; then
+          commands=$commands" mount"
+        fi
+        for command in $commands
+        do
+          "$BIN" --generate-man-page=$command > "$ARCHIVE/doc/${{ matrix.tool }}-$command.1"
+        done
+
+    - name: Build archive (Windows)
+      shell: bash
+      if: matrix.os == 'windows-latest'
+      run: |
+        7z a "$ARCHIVE.zip" "$ARCHIVE"
+        certutil -hashfile "$ARCHIVE.zip" SHA256 > "$ARCHIVE.zip.sha256"
+        echo "ASSET=$ARCHIVE.zip" >> $GITHUB_ENV
+        echo "ASSET_SUM=$ARCHIVE.zip.sha256" >> $GITHUB_ENV
+
+    - name: Build archive (Unix)
+      shell: bash
+      if: matrix.os != 'windows-latest'
+      run: |
+        tar czf "$ARCHIVE.tar.gz" "$ARCHIVE"
+        shasum -a 256 "$ARCHIVE.tar.gz" > "$ARCHIVE.tar.gz.sha256"
+        echo "ASSET=$ARCHIVE.tar.gz" >> $GITHUB_ENV
+        echo "ASSET_SUM=$ARCHIVE.tar.gz.sha256" >> $GITHUB_ENV
+
+    - name: Upload release archive
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        version="${{ needs.create-release.outputs.version }}"
+      #  gh release upload "$version" ${{ env.ASSET }} ${{ env.ASSET_SUM }}
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: pre_release-${{ matrix.build }}-${{ matrix.tool }}
+        path: |
+          ${{ env.ASSET }}
+        compression-level: 0

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -3,7 +3,7 @@ name: Pre-Release
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+(-[0-9a-zA-Z]+)?"
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Publication
+
+on:
+  release:
+    types: [released]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  do_publication:
+    name: Publish on crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Publish
+        env:
+         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+            cargo publish -p libarx
+            cargo publish -p arx
+            cargo publish -p tar2arx
+            cargo publish -p zip2arx

--- a/arx/src/main.rs
+++ b/arx/src/main.rs
@@ -24,6 +24,7 @@ struct Cli {
         default_missing_value = "",
         help_heading = "Advanced",
         value_parser([
+            "",
             "create",
             "list",
             "dump",

--- a/zip2arx/Cargo.toml
+++ b/zip2arx/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arx = { path = "../libarx", version = "0.2.0", package="libarx", features=["cmd_utils"] }
+arx = { path = "../libarx", version = "0.2.0", package="libarx", features=["cmd_utils", "zstd"] }
 jbk.workspace = true
 clap.workspace = true
 indicatif.workspace = true


### PR DESCRIPTION
Add a series of workflows to automate the release process:
- Workflow "Check Release" triggered when a new PR on branch "r/version". Check everything is Ok
- Workflow "Pre Release", triggered on tag "version", to create a github release and populate with prebuild binaries
- A workflow "Release", triggered when release is finalised, to publish on crates.io.

Fix #10 #11