### PR TITLE
Add a `recurse` option to extract all files/dirs in an given directory.

### DIFF
--- a/arx/src/extract.rs
+++ b/arx/src/extract.rs
@@ -37,6 +37,27 @@ pub struct Options {
     #[arg(from_global)]
     verbose: u8,
 
+    /// Recursively extract directories
+    ///
+    /// Default value is true if `EXTRACT_FILES` is passed and false is `FILE_LIST` is passed.
+    #[arg(
+        short,
+        long,
+        required = false,
+        default_value_t = false,
+        default_value_ifs([
+            ("no_recurse", clap::builder::ArgPredicate::IsPresent, "false"),
+            ("extract_files", clap::builder::ArgPredicate::IsPresent, "true")
+        ]),
+        conflicts_with = "no_recurse",
+        action
+    )]
+    recurse: bool,
+
+    /// Force `--recurse` to be false.
+    #[arg(long)]
+    no_recurse: bool,
+
     #[arg(
         short = 'f',
         long = "file",
@@ -72,5 +93,11 @@ pub fn extract(options: Options) -> jbk::Result<()> {
         options.infile.as_ref().unwrap()
     };
     info!("Extract archive {:?} in {:?}", &infile, outdir);
-    arx::extract(infile, &outdir, files_to_extract, options.progress)
+    arx::extract(
+        infile,
+        &outdir,
+        files_to_extract,
+        options.recurse,
+        options.progress,
+    )
 }

--- a/arx/tests/create.rs
+++ b/arx/tests/create.rs
@@ -5,7 +5,8 @@ mod inner {
 
     // Generate a fake directory with fake content.
     pub fn spawn_mount() -> std::io::Result<(arx_test_dir::BackgroundSession, PathBuf)> {
-        let mount_path = tempfile::TempDir::new_in(env!("CARGO_TARGET_TMPDIR")).unwrap();
+        let mount_path =
+            tempfile::TempDir::with_prefix_in("source_", env!("CARGO_TARGET_TMPDIR")).unwrap();
         let builder = arx_test_dir::ContextBuilder::new();
         let context = builder.create();
         let dir = arx_test_dir::DirEntry::new_root(context);
@@ -19,7 +20,7 @@ mod inner {
 
 #[cfg(all(unix, not(feature = "in_ci")))]
 #[test]
-fn test_create() {
+fn test_create_and_mount() {
     use inner::*;
 
     let (_source_mount_handle, source_mount_point) = spawn_mount().unwrap();
@@ -35,8 +36,9 @@ fn test_create() {
         .arg("--strip-prefix")
         .arg(&source_mount_point.file_name().unwrap())
         .arg(&source_mount_point.file_name().unwrap())
+        .arg("--progress")
         .output()
-        .expect("foo");
+        .expect("Creation should work");
     println!("Out : {}", String::from_utf8(output.stdout).unwrap());
     println!("Err : {}", String::from_utf8(output.stderr).unwrap());
     assert!(output.status.success());
@@ -52,6 +54,110 @@ fn test_create() {
         .arg("-r")
         .arg(&source_mount_point)
         .arg(&mount_point.path())
+        .output()
+        .unwrap();
+    println!("Out : {}", String::from_utf8(output.stdout).unwrap());
+    println!("Err: {}", String::from_utf8(output.stderr).unwrap());
+    assert!(output.status.success());
+}
+
+#[cfg(all(unix, not(feature = "in_ci")))]
+#[test]
+fn test_create_and_extract() {
+    use inner::*;
+
+    let (_source_mount_handle, source_mount_point) = spawn_mount().unwrap();
+    let bin_path = env!("CARGO_BIN_EXE_arx");
+    let arx_file = Path::new(env!("CARGO_TARGET_TMPDIR")).join("test.arx");
+    let output = Command::new(bin_path)
+        .arg("--verbose")
+        .arg("create")
+        .arg("--outfile")
+        .arg(&arx_file)
+        .arg("-C")
+        .arg(&source_mount_point.parent().unwrap())
+        .arg("--strip-prefix")
+        .arg(&source_mount_point.file_name().unwrap())
+        .arg(&source_mount_point.file_name().unwrap())
+        .arg("--progress")
+        .output()
+        .expect("Creation should work");
+    println!("Out : {}", String::from_utf8(output.stdout).unwrap());
+    println!("Err : {}", String::from_utf8(output.stderr).unwrap());
+    assert!(output.status.success());
+    assert!(arx_file.is_file());
+
+    let extract_dir = tempfile::TempDir::new_in(env!("CARGO_TARGET_TMPDIR")).unwrap();
+    arx::extract(
+        &arx_file,
+        extract_dir.path(),
+        Default::default(),
+        true,
+        false,
+    )
+    .unwrap();
+    let output = Command::new("diff")
+        .arg("-r")
+        .arg(&source_mount_point)
+        .arg(&extract_dir.path())
+        .output()
+        .unwrap();
+    println!("Out : {}", String::from_utf8(output.stdout).unwrap());
+    println!("Err: {}", String::from_utf8(output.stderr).unwrap());
+    assert!(output.status.success());
+}
+
+#[cfg(all(unix, not(feature = "in_ci")))]
+#[test]
+fn test_create_and_extract_subdir() {
+    use inner::*;
+
+    let (_source_mount_handle, source_mount_point) = spawn_mount().unwrap();
+    let bin_path = env!("CARGO_BIN_EXE_arx");
+    let arx_file = Path::new(env!("CARGO_TARGET_TMPDIR")).join("test.arx");
+    let output = Command::new(bin_path)
+        .arg("--verbose")
+        .arg("create")
+        .arg("--outfile")
+        .arg(&arx_file)
+        .arg("-C")
+        .arg(&source_mount_point.parent().unwrap())
+        .arg("--strip-prefix")
+        .arg(&source_mount_point.file_name().unwrap())
+        .arg(&source_mount_point.file_name().unwrap())
+        .arg("--progress")
+        .output()
+        .expect("Creation should work");
+    println!("Out : {}", String::from_utf8(output.stdout).unwrap());
+    println!("Err : {}", String::from_utf8(output.stderr).unwrap());
+    assert!(output.status.success());
+    assert!(arx_file.is_file());
+
+    let extract_dir =
+        tempfile::TempDir::with_prefix_in("extract_", env!("CARGO_TARGET_TMPDIR")).unwrap();
+    arx::extract(
+        &arx_file,
+        extract_dir.path(),
+        ["OrcBlIw".into()].into(),
+        true,
+        true,
+    )
+    .unwrap();
+
+    let mut source_sub_dir = source_mount_point;
+    source_sub_dir.push("OrcBlIw");
+    let mut extract_sub_dir = extract_dir.path().to_path_buf();
+    extract_sub_dir.push("OrcBlIw");
+
+    println!(
+        "Diff {} and {}",
+        source_sub_dir.display(),
+        extract_sub_dir.display()
+    );
+    let output = Command::new("diff")
+        .arg("-r")
+        .arg(&source_sub_dir)
+        .arg(&extract_sub_dir)
         .output()
         .unwrap();
     println!("Out : {}", String::from_utf8(output.stdout).unwrap());

--- a/python/src/arx.rs
+++ b/python/src/arx.rs
@@ -115,7 +115,7 @@ impl Arx {
     /// Extract the whole archive in
     #[pyo3(signature=(extract_path=std::path::PathBuf::from(".")))]
     fn extract(&self, extract_path: std::path::PathBuf) -> PyResult<()> {
-        arx::extract_arx(&self.0, &extract_path, Default::default(), false)
+        arx::extract_arx(&self.0, &extract_path, Default::default(), true, false)
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 }


### PR DESCRIPTION
Initial tests was made:
- without directory in EXTRACT_FILES (only files),
- without EXTRACT_FILES at all
- with a FILE_LIST given from gnome file-roller (containing directory AND subfiles)

This obvious option was missing.

Fix #43