### PR TITLE
Introduce option `root-dir` to extract.

### DIFF
--- a/arx/tests/create.rs
+++ b/arx/tests/create.rs
@@ -109,7 +109,7 @@ fn test_create_and_extract() {
 
 #[cfg(all(unix, not(feature = "in_ci")))]
 #[test]
-fn test_create_and_extract_subdir() {
+fn test_create_and_extract_filter() {
     use inner::*;
 
     let (_source_mount_handle, source_mount_point) = spawn_mount().unwrap();
@@ -163,4 +163,107 @@ fn test_create_and_extract_subdir() {
     println!("Out : {}", String::from_utf8(output.stdout).unwrap());
     println!("Err: {}", String::from_utf8(output.stderr).unwrap());
     assert!(output.status.success());
+}
+
+#[cfg(all(unix, not(feature = "in_ci")))]
+#[test]
+fn test_create_and_extract_subdir() {
+    use inner::*;
+
+    let (_source_mount_handle, source_mount_point) = spawn_mount().unwrap();
+    let bin_path = env!("CARGO_BIN_EXE_arx");
+    let arx_file = Path::new(env!("CARGO_TARGET_TMPDIR")).join("test.arx");
+    let output = Command::new(bin_path)
+        .arg("--verbose")
+        .arg("create")
+        .arg("--outfile")
+        .arg(&arx_file)
+        .arg("-C")
+        .arg(&source_mount_point.parent().unwrap())
+        .arg("--strip-prefix")
+        .arg(&source_mount_point.file_name().unwrap())
+        .arg(&source_mount_point.file_name().unwrap())
+        .arg("--progress")
+        .output()
+        .expect("Creation should work");
+    println!("Out : {}", String::from_utf8(output.stdout).unwrap());
+    println!("Err : {}", String::from_utf8(output.stderr).unwrap());
+    assert!(output.status.success());
+    assert!(arx_file.is_file());
+
+    let extract_dir =
+        tempfile::TempDir::with_prefix_in("extract_", env!("CARGO_TARGET_TMPDIR")).unwrap();
+
+    let status = Command::new(bin_path)
+        .arg("extract")
+        .arg("--verbose")
+        .arg(&arx_file)
+        .arg("--root-dir")
+        .arg("OrcBlIw/tuyuMO7")
+        .arg("-C")
+        .arg(&extract_dir.path())
+        .status()
+        .expect("Extract should work");
+    assert!(status.success());
+
+    let mut source_sub_dir = source_mount_point;
+    source_sub_dir.push("OrcBlIw");
+    source_sub_dir.push("tuyuMO7");
+
+    println!(
+        "Diff {} and {}",
+        source_sub_dir.display(),
+        extract_dir.path().display()
+    );
+    let output = Command::new("diff")
+        .arg("-r")
+        .arg(&source_sub_dir)
+        .arg(&extract_dir.path())
+        .output()
+        .unwrap();
+    println!("Out: {}", String::from_utf8(output.stdout).unwrap());
+    println!("Err: {}", String::from_utf8(output.stderr).unwrap());
+    assert!(output.status.success());
+}
+
+#[cfg(all(unix, not(feature = "in_ci")))]
+#[test]
+fn test_create_and_extract_subfile() {
+    use inner::*;
+
+    let (_source_mount_handle, source_mount_point) = spawn_mount().unwrap();
+    let bin_path = env!("CARGO_BIN_EXE_arx");
+    let arx_file = Path::new(env!("CARGO_TARGET_TMPDIR")).join("test.arx");
+    let output = Command::new(bin_path)
+        .arg("--verbose")
+        .arg("create")
+        .arg("--outfile")
+        .arg(&arx_file)
+        .arg("-C")
+        .arg(&source_mount_point.parent().unwrap())
+        .arg("--strip-prefix")
+        .arg(&source_mount_point.file_name().unwrap())
+        .arg(&source_mount_point.file_name().unwrap())
+        .arg("--progress")
+        .output()
+        .expect("Creation should work");
+    println!("Out : {}", String::from_utf8(output.stdout).unwrap());
+    println!("Err : {}", String::from_utf8(output.stderr).unwrap());
+    assert!(output.status.success());
+    assert!(arx_file.is_file());
+
+    let extract_dir =
+        tempfile::TempDir::with_prefix_in("extract_", env!("CARGO_TARGET_TMPDIR")).unwrap();
+
+    let status = Command::new(bin_path)
+        .arg("extract")
+        .arg("--verbose")
+        .arg(&arx_file)
+        .arg("--root-dir")
+        .arg("OrcBlIw/8w5EKLr.text")
+        .arg("-C")
+        .arg(&extract_dir.path())
+        .status()
+        .expect("Extract should work");
+    assert!(!status.success());
 }

--- a/libarx/src/lib.rs
+++ b/libarx/src/lib.rs
@@ -19,5 +19,5 @@ pub use common::{
     PathBuf, VENDOR_ID,
 };
 pub use entry::*;
-pub use tools::{extract, extract_arx};
+pub use tools::{extract, extract_arx, extract_arx_range};
 pub use walk::*;

--- a/libarx/src/tools.rs
+++ b/libarx/src/tools.rs
@@ -293,3 +293,25 @@ pub fn extract_arx(
         walker.run(&extractor)
     })
 }
+
+pub fn extract_arx_range<R: jbk::reader::Range + Sync>(
+    arx: &Arx,
+    outdir: &Path,
+    range: &R,
+    files_to_extract: HashSet<crate::PathBuf>,
+    recurse: bool,
+    progress: bool,
+) -> jbk::Result<()> {
+    let mut walker = Walker::new(arx, Default::default());
+    rayon::scope(|scope| {
+        let extractor = Extractor {
+            arx,
+            scope,
+            files: files_to_extract,
+            base_dir: outdir.to_path_buf(),
+            print_progress: progress,
+            recurse,
+        };
+        walker.run_from_range(&extractor, range)
+    })
+}

--- a/libarx/src/walk.rs
+++ b/libarx/src/walk.rs
@@ -48,6 +48,21 @@ impl<'a, Context> Walker<'a, Context> {
         op.on_stop(&mut self.context)
     }
 
+    pub fn run_from_range<R: Range, B>(
+        &mut self,
+        op: &dyn Operator<Context, B>,
+        range: &R,
+    ) -> jbk::Result<()>
+    where
+        B: FullBuilderTrait,
+    {
+        let builder = RealBuilder::<B>::new(&self.arx.properties);
+
+        op.on_start(&mut self.context)?;
+        self._run(range, &builder, op)?;
+        op.on_stop(&mut self.context)
+    }
+
     fn _run<R: Range, B>(
         &mut self,
         range: &R,


### PR DESCRIPTION
This allow to extract from a directory as root, instead of true root of archive.

This is equivalent to a "cd <root_dir>" before walking tree and filter.

Fix #47

This also add the same option to `mount` sub_command simply because we can.