### PR TITLE
Fix Python CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,13 +6,9 @@
 name: Python wrapping
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - '*'
   pull_request:
-  workflow_dispatch:
+  release:
+    types: [released]
 
 permissions:
   contents: read
@@ -25,13 +21,14 @@ jobs:
         platform:
           - runner: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install dependencies
         run: |
           sudo apt-get install -y libfuse-dev
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -42,8 +39,8 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux
-          path: dist
+          name: wheels-linux-x86_64
+          path: python/dist
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -52,10 +49,11 @@ jobs:
         platform:
           - runner: windows-latest
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -65,8 +63,8 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-windows
-          path: dist
+          name: wheels-windows-x64
+          path: python/dist
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
@@ -75,13 +73,14 @@ jobs:
         platform:
           - runner: macos-latest
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install dependencies
         run: |
           brew install macfuse
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -91,13 +90,14 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos
-          path: dist
+          name: wheels-macos-x86_64
+          path: python/dist
 
   sdist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
@@ -108,20 +108,19 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-sdist
-          path: dist
+          path: python/dist
 
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [sdist]
+    if: "github.event_name == 'release'"
+    needs: [linux, windows, macos, sdist]
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*
-          working-directory: python

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "python-libarx"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "jubako",
  "libarx",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "python-libarx"
-version = "0.1.0"
-edition = "2021"
+description = "Python wrapper around arx library."
+categories = ["compression", "filesystem"]
+keywords = ["archive-format", "extract", "file-format", "compression"]
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]


### PR DESCRIPTION
Release job now use PyPI's trusted publishing.