### PR TITLE
Python's `get_content()` now returns a `Stream` object instead of `bytes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,8 +896,7 @@ dependencies = [
 
 [[package]]
 name = "jubako"
-version = "0.3.1"
-source = "git+https://github.com/jubako/jubako.git#9f7eaee8e01f7096fb724869bd619c9cdb6af4aa"
+version = "0.3.2-dev"
 dependencies = [
  "blake3",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/jubako/arx"
 license = "MIT"
 
 [workspace.dependencies]
-jbk = { git = "https://github.com/jubako/jubako.git", package = "jubako", version = "0.3.1" }
+jbk = { git = "https://github.com/jubako/jubako.git", package = "jubako", version = "0.3.2-dev" }
 clap = { version = "4.4.5", features = ["derive"] }
 clap_mangen = "0.2.20"
 clap_complete = "4.5.0"

--- a/python/src/entry.rs
+++ b/python/src/entry.rs
@@ -6,7 +6,7 @@ use pyo3::{
     prelude::*,
 };
 
-use crate::{content_address::ContentAddress, iterator::EntryIter};
+use crate::{content_address::ContentAddress, iterator::EntryIter, stream::Stream};
 
 /// An entry i an arx archive.
 ///
@@ -148,9 +148,9 @@ impl Entry {
     /// Get the content of the file entry.
     ///
     /// Raise an exception if entry is not a file.
-    fn get_content<'py>(&self, py: Python<'py>) -> PyResult<&'py pyo3::types::PyBytes> {
+    fn get_content(&self) -> PyResult<Stream> {
         match &self.entry {
-            arx::Entry::File(f) => super::arx::Arx::get_content_rust(&self.arx, py, f.content()),
+            arx::Entry::File(f) => super::arx::Arx::get_content_rust(&self.arx, f.content()),
             _ => Err(PyTypeError::new_err("Not a file")),
         }
     }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -3,6 +3,7 @@ mod content_address;
 mod creator;
 mod entry;
 mod iterator;
+mod stream;
 use pyo3::prelude::*;
 
 /// A Python module implemented in Rust.

--- a/python/src/stream.rs
+++ b/python/src/stream.rs
@@ -1,0 +1,38 @@
+use jbk::reader::ByteStream;
+use pyo3::prelude::*;
+use std::io::Read;
+
+#[pyclass]
+pub struct Stream(pub ByteStream);
+
+#[pymethods]
+impl Stream {
+    /// Read `size` bytes from the stream.
+    ///
+    /// Returned `bytes` may be shorter than `size` if data left to be read is smaller than requested.
+    fn read<'py>(&mut self, py: Python<'py>, size: usize) -> PyResult<&'py pyo3::types::PyBytes> {
+        let size = std::cmp::min(size, self.0.size_left() as usize);
+        let read_fn = |slice: &mut [u8]| {
+            self.0.read_exact(slice).unwrap();
+            Ok(())
+        };
+        pyo3::types::PyBytes::new_with(py, size, read_fn)
+    }
+
+    /// Get the full size of the stream.
+    fn size(&self) -> u64 {
+        self.0.size()
+    }
+
+    /// Get the size of the data left to read.
+    ///
+    /// Equivalent to `size() - tell()`
+    fn size_left(&self) -> u64 {
+        self.0.size_left()
+    }
+
+    /// Get the current offset (already read data) of the stream.
+    fn tell(&self) -> u64 {
+        self.0.offset()
+    }
+}


### PR DESCRIPTION
Use will have to read from the `Stream` to get (several) `bytes` objects.

Fix #63 