### PR TITLE
Update python wrapping to last version of pyo3 (0.22)

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -18,4 +18,4 @@ crate-type = ["cdylib"]
 [dependencies]
 jbk.workspace = true
 arx = { path = "../libarx", version = "0.3.0", package = "libarx"}
-pyo3 = "0.20.0"
+pyo3 = "0.22"

--- a/python/src/arx.rs
+++ b/python/src/arx.rs
@@ -66,7 +66,7 @@ impl Arx {
 #[pymethods]
 impl Arx {
     #[new]
-    fn py_new(path: &PyUnicode) -> PyResult<Self> {
+    fn py_new<'py>(path: Bound<'py, PyUnicode>) -> PyResult<Self> {
         let path: std::path::PathBuf = path.extract()?;
         match arx::Arx::new(path) {
             Ok(a) => Ok(Self::new(a)),

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn libarx(_py: Python, m: &PyModule) -> PyResult<()> {
+fn libarx<'py>(_py: Python, m: Bound<'py, PyModule>) -> PyResult<()> {
     m.add_class::<arx::Arx>()?;
     m.add_class::<entry::Entry>()?;
     m.add_class::<content_address::ContentAddress>()?;

--- a/python/src/stream.rs
+++ b/python/src/stream.rs
@@ -10,13 +10,17 @@ impl Stream {
     /// Read `size` bytes from the stream.
     ///
     /// Returned `bytes` may be shorter than `size` if data left to be read is smaller than requested.
-    fn read<'py>(&mut self, py: Python<'py>, size: usize) -> PyResult<&'py pyo3::types::PyBytes> {
+    fn read<'py>(
+        &mut self,
+        py: Python<'py>,
+        size: usize,
+    ) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
         let size = std::cmp::min(size, self.0.size_left() as usize);
         let read_fn = |slice: &mut [u8]| {
             self.0.read_exact(slice).unwrap();
             Ok(())
         };
-        pyo3::types::PyBytes::new_with(py, size, read_fn)
+        pyo3::types::PyBytes::new_bound_with(py, size, read_fn)
     }
 
     /// Get the full size of the stream.


### PR DESCRIPTION
This is necessary to support python 3.13