### PR TITLE
Fix `arx create` with file list option.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
+ "color-print",
  "daemonize",
  "env_logger",
  "human-panic",
@@ -390,6 +391,27 @@ checksum = "f17415fd4dfbea46e3274fcd8d368284519b358654772afb700dc2e8d2b24eeb"
 dependencies = [
  "clap",
  "roff",
+]
+
+[[package]]
+name = "color-print"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4"
+dependencies = [
+ "color-print-proc-macro",
+]
+
+[[package]]
+name = "color-print-proc-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692186b5ebe54007e45a59aea47ece9eb4108e141326c304cdc91699a7118a22"
+dependencies = [
+ "nom",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1057,6 +1079,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1115,16 @@ dependencies = [
  "thiserror",
  "xz2",
  "zstd 0.12.4",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,7 @@ dependencies = [
  "fxhash",
  "jubako",
  "libc",
+ "log",
  "lru",
  "rayon",
  "relative-path",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,6 @@ dependencies = [
 [[package]]
 name = "arx_test_dir"
 version = "0.1.0"
-source = "git+https://github.com/jubako/arx_test_dir.git#b818e3c70401edf731748577da376fccb6b2058c"
 dependencies = [
  "clap",
  "fuser 0.13.0",
@@ -371,7 +370,7 @@ version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -732,12 +731,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -900,7 +893,6 @@ version = "0.3.2-dev"
 dependencies = [
  "blake3",
  "bstr",
- "clap",
  "crc",
  "deranged",
  "dropout",
@@ -975,16 +967,6 @@ checksum = "636860251af8963cc40f6b4baadee105f02e21b28131d76eba8e40ce84ab8064"
 dependencies = [
  "rand",
  "rand_chacha",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
 ]
 
 [[package]]
@@ -1174,29 +1156,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,15 +1215,15 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -1274,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1284,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1294,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1306,11 +1265,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -1509,12 +1468,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"

--- a/arx/Cargo.toml
+++ b/arx/Cargo.toml
@@ -24,6 +24,7 @@ env_logger = "0.10.0"
 log = "0.4.20"
 tempfile = "3.10.1"
 libc = "0.2.158"
+color-print = "0.3.7"
 
 [target.'cfg(unix)'.dependencies]
 daemonize = "0.5.0"

--- a/arx/Cargo.toml
+++ b/arx/Cargo.toml
@@ -29,7 +29,7 @@ libc = "0.2.158"
 daemonize = "0.5.0"
 
 [target.'cfg(not(windows))'.dev-dependencies]
-arx_test_dir = { git = "https://github.com/jubako/arx_test_dir.git" }
+arx_test_dir = { git = "https://github.com/jubako/arx_test_dir.git", features = ["fuse"] }
 tempfile = "3.8.0"
 
 [features]
@@ -38,7 +38,7 @@ in_ci = []
 lz4 = ["arx/lz4"]
 zstd = ["arx/zstd"]
 lzma = ["arx/lzma"]
-fuse = ["arx/fuse", "arx_test_dir/fuse"]
+fuse = ["arx/fuse"]
 
 [[bin]]
 name = "auto_mount"

--- a/arx/src/create.rs
+++ b/arx/src/create.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Context, Result};
+use color_print::cstr;
 use log::{debug, info};
 use std::cell::Cell;
 use std::fs::File;
@@ -9,8 +10,70 @@ use std::sync::Arc;
 
 use clap::{Parser, ValueHint};
 
+const AFTER_HELP: &'static str = cstr!(
+    "
+<s,u>Specifying input files:</>
+
+<s>From command line ([INFILES])</s>
+
+The command format is :
+<i>$ arx -o my_archive.arx input_file1 input_file2 input_dir1 ...</i>
+In this mode, <i>--recurse</i> is true by default.
+
+<s>From list file ([FILE_LIST])</s>
+
+The command format is :
+<i>$ arx -o my_archive.arx -L file_list.txt</i>
+In this mode, <i>--recurse</i> is false by default.
+
+File list can be generated this way :
+<i>$ find input_dir > file_list.txt</i>
+
+You can apply filters on this list if you want to.
+
+<s>Tree structure and directory creation</s>
+
+Arx store files using a tree structure of Directory/File/Link so a file <s>foo/bar.txt</s> cannot
+exists without a directory <s>foo</s>.
+
+When adding <i>foo</i> directory recursively, both <i>foo</i> and <i>foo/bar.txt</i> are added
+using attribute from filesystem metadata (stats on Linux)
+When directly adding <i>foo/bar.txt</i>, <i>foo</i> directory is automatically created using default
+metadata:
+- owner and group: 1000,
+- right: 0x755,
+- mtime: 0
+
+This is the same thing when using file list. It is preferable to list both directories and files in the listing:
+```
+foo
+foo/bar.txt
+```
+(If you've used <i>find</i> to generate the list : don't use <i>-type f</i> option)
+
+<s>About file list and <i>--follow-symlink</i> option</s>
+
+Listing in file list and <i>--follow-symlink</i> passed to arx, you must be coherent.
+Follow symlink all the time or never.
+If you don't, you may have incoherent state when symlink are pointing to directories.
+
+<s,u>Compression detection/selection:</>
+
+Arx automatically detect if a content should be compressed or not based on a heuristic using
+Shannon entropy.
+You can select which compression algorithm is used using <i>--compression</i> option, either
+<i>--compression <<algorithm></i> or <i>--compression <<algorithm>=<<level></i>.
+List of available compression algorithms can be obtained using <i>--list-compressions</i> option.
+You can use <i>--compresssion none</i> to deactivate compression.
+It is not possible to force compression of content (patch welcome).
+"
+);
+
+const USAGE: &'static str = cstr!("<s>arx create</s> -o archive.arx [OPTIONS] [INFILES]...");
+
 /// Create an archive.
 #[derive(Parser, Debug)]
+#[command(after_long_help=AFTER_HELP, override_usage=USAGE)]
 pub struct Options {
     /// File path of the archive to create.
     ///
@@ -21,18 +84,20 @@ pub struct Options {
         long,
         value_parser,
         required_unless_present("list_compressions"),
-        value_hint=ValueHint::FilePath
+        value_hint=ValueHint::FilePath,
     )]
     outfile: Option<PathBuf>,
 
     /// Remove STRIP_PREFIX from the entries' name added to the archive.
-    #[arg(long, required = false, value_hint=ValueHint::DirPath)]
+    #[arg(long, required = false, value_hint=ValueHint::DirPath, help_heading="Input options")]
     strip_prefix: Option<arx::PathBuf>,
 
     /// Move to BASE_DIR before starting adding content to arx archive.
     ///
     /// Argument `INFILES` or `STRIP_PREFIX` must be relative to `BASE_DIR`.
-    #[arg(short = 'C', required = false, value_hint=ValueHint::DirPath)]
+    /// `OUTFILE` and `FILE_LIST` path is always relative to current directory.
+    /// Paths listed in `FILE_LIST` are related to `BASED_DIR`
+    #[arg(short = 'C', required = false, value_hint=ValueHint::DirPath, verbatim_doc_comment, help_heading="Input options")]
     base_dir: Option<PathBuf>,
 
     /// Input files/directories
@@ -44,17 +109,19 @@ pub struct Options {
     ///
     /// Arx is storing only relative path. If INFILES contains absolute paths, root
     /// prefix is removed.
-    #[arg(value_parser, group = "input", value_hint=ValueHint::AnyPath)]
+    #[arg(value_parser, group = "input", value_hint=ValueHint::AnyPath, help_heading="Input options")]
     infiles: Vec<PathBuf>,
 
     /// Get the list of files/directories to add from the FILE_LIST (incompatible with INFILES)
     ///
     /// This is an option incompatible with `INFILES`.
     ///
+    /// Relative path are relative to the current working dir. `BASE_DIR` option is used after resolving relative path.
+    ///
     /// In this mode, `recurse` is false by default.
     /// This allow FILE_LIST listing both the directory and (subset of) files in the given directory.
     /// Use `--recurse` to activate recursion.
-    #[arg(short = 'L', long = "file-list", group = "input", verbatim_doc_comment, value_hint=ValueHint::FilePath)]
+    #[arg(short = 'L', long = "file-list", group = "input", verbatim_doc_comment, value_hint=ValueHint::FilePath, help_heading="Input options")]
     file_list: Option<PathBuf>,
 
     /// Recurse in directories
@@ -70,12 +137,12 @@ pub struct Options {
             ("infiles", clap::builder::ArgPredicate::IsPresent, "true")
         ]),
         conflicts_with = "no_recurse",
-        action
+        action, help_heading="Input options"
     )]
     recurse: bool,
 
     /// Force `--recurse` to be false.
-    #[arg(long)]
+    #[arg(long, help_heading = "Input options")]
     no_recurse: bool,
 
     #[command(flatten)]
@@ -89,13 +156,22 @@ pub struct Options {
     #[arg(long, default_value_t = false, action)]
     list_compressions: bool,
 
+    /// Print a progression of the creation
     #[arg(long, default_value_t = false, action)]
     progress: bool,
 
+    /// Overwrite existing archive file
     #[arg(short, long, required = false, default_value_t = false, action)]
     force: bool,
 
-    #[arg(long, required = false, default_value_t = false, action)]
+    /// Follow symbolic link found in the input files
+    #[arg(
+        long,
+        required = false,
+        default_value_t = false,
+        action,
+        help_heading = "Input options"
+    )]
     follow_symlink: bool,
 
     #[arg(from_global)]

--- a/libarx/Cargo.toml
+++ b/libarx/Cargo.toml
@@ -24,6 +24,7 @@ relative-path = "1.9.2"
 epochs = "0.2.4"
 rayon = "1.10.0"
 bstr = "1.9.1"
+log = "0.4.22"
 
 [target.'cfg(not(windows))'.dependencies]
 fuser = { version = "0.14.0", optional = true }

--- a/libarx/src/cmd_utils.rs
+++ b/libarx/src/cmd_utils.rs
@@ -67,15 +67,36 @@ impl std::error::Error for InvalidCompression {}
 #[derive(clap::Args, Debug)]
 #[group(required = false, multiple = false)]
 pub struct ConcatMode {
-    #[arg(short = '1', long, required = false, default_value_t = false, action)]
+    #[arg(
+        short = '1',
+        long,
+        required = false,
+        default_value_t = false,
+        action,
+        help_heading = "Advanced options"
+    )]
     /// Create only one file (default)
     one_file: bool,
 
-    #[arg(short = '2', long, required = false, default_value_t = false, action)]
+    #[arg(
+        short = '2',
+        long,
+        required = false,
+        default_value_t = false,
+        action,
+        help_heading = "Advanced options"
+    )]
     /// Create two files (a content pack and other)
     two_files: bool,
 
-    #[arg(short = 'N', long, required = false, default_value_t = false, action)]
+    #[arg(
+        short = 'N',
+        long,
+        required = false,
+        default_value_t = false,
+        action,
+        help_heading = "Advanced options"
+    )]
     /// Create mulitples files (one per pack)
     multiple_files: bool,
 }

--- a/libarx/src/create/fs_adder.rs
+++ b/libarx/src/create/fs_adder.rs
@@ -196,6 +196,16 @@ impl<'a> FsAdder<'a> {
         Ok(())
     }
 
+    pub fn add_from_list<Iter>(&mut self, paths: Iter, follow_symlink: bool) -> Void
+    where
+        Iter: Iterator<Item = std::path::PathBuf>,
+    {
+        for path in paths {
+            self.add_entry_from_path(&path, follow_symlink)?;
+        }
+        Ok(())
+    }
+
     pub fn add_entry_from_path(&mut self, path: &std::path::Path, follow_symlink: bool) -> Void {
         log::debug!("add_path(path:{path:?}, follow_symlink:{follow_symlink})");
 

--- a/libarx/src/create/fs_adder.rs
+++ b/libarx/src/create/fs_adder.rs
@@ -1,23 +1,32 @@
 use crate::create::{EntryKind, EntryTrait, SimpleCreator, Void};
 use bstr::{BString, ByteVec};
 use jbk::creator::InputReader;
+use std::fs::Metadata;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 #[cfg(windows)]
 use std::os::windows::fs::MetadataExt;
 use std::path::PathBuf;
-use std::{fs, io::Cursor, sync::mpsc, thread::spawn};
+use std::{io::Cursor, sync::mpsc, thread::spawn};
 
+#[derive(Debug)]
 pub enum FsEntryKind {
     Dir,
     File(jbk::Size, jbk::ContentAddress),
-    Link,
+    Link(PathBuf),
+    Other,
+}
+
+#[derive(Debug)]
+pub enum DetectedEntryKind {
+    Dir,
+    File(u64, PathBuf),
+    Link(PathBuf),
     Other,
 }
 
 pub struct FsEntry {
     pub kind: FsEntryKind,
-    pub fs_path: PathBuf,
     pub arx_path: crate::PathBuf,
     uid: u64,
     gid: u64,
@@ -25,46 +34,58 @@ pub struct FsEntry {
     mtime: u64,
 }
 
+fn detect_kind(
+    mut path: PathBuf,
+    follow_symlink: bool,
+) -> jbk::Result<(DetectedEntryKind, Metadata)> {
+    log::trace!("std::fs::symlink_metadata({path:?})");
+    let mut attr = std::fs::symlink_metadata(&path)?;
+    log::trace!("=> {attr:?}");
+
+    if attr.is_symlink() && follow_symlink {
+        path = std::fs::canonicalize(path)?;
+        log::trace!("New path is {path:?}");
+        attr = std::fs::symlink_metadata(&path)?;
+        log::trace!("New attr is {attr:?}");
+    }
+    let kind = if attr.is_dir() {
+        DetectedEntryKind::Dir
+    } else if attr.is_file() {
+        DetectedEntryKind::File(attr.len(), path)
+    } else if attr.is_symlink() {
+        DetectedEntryKind::Link(path)
+    } else {
+        DetectedEntryKind::Other
+    };
+    Ok((kind, attr))
+}
+
 impl FsEntry {
-    pub fn new_from_walk_entry<A: jbk::creator::ContentAdder>(
-        dir_entry: walkdir::DirEntry,
+    pub fn new_from_path<A: jbk::creator::ContentAdder>(
+        fs_path: &std::path::Path,
         arx_path: crate::PathBuf,
         adder: &mut A,
-        is_root_entry: bool,
+        follow_symlink: bool,
     ) -> jbk::Result<Box<Self>> {
-        let fs_path = dir_entry.path().to_path_buf();
-        let attr = dir_entry.metadata().map_err(std::io::Error::from)?;
-        let kind = if attr.is_dir() {
-            FsEntryKind::Dir
-        } else if attr.is_file() {
-            let reader: Box<dyn InputReader> = if attr.len() < 1024 * 1024 {
-                let content = std::fs::read(&fs_path)?;
-                Box::new(Cursor::new(content))
-            } else {
-                Box::new(jbk::creator::InputFile::open(&fs_path)?)
-            };
-            let content_address = adder.add_content(reader, jbk::creator::CompHint::Detect)?;
-            FsEntryKind::File(attr.len().into(), content_address)
-        } else if attr.is_symlink() {
-            if is_root_entry {
-                // Walkdir will return it is a link but will follow it if it is a directory.
-                let target_attr = std::fs::metadata(std::fs::read_link(dir_entry.path())?)?;
-                if target_attr.is_dir() {
-                    FsEntryKind::Dir
+        let (kind, attr) = detect_kind(fs_path.to_path_buf(), follow_symlink)?;
+        let kind = match kind {
+            DetectedEntryKind::Dir => FsEntryKind::Dir,
+            DetectedEntryKind::File(file_size, path) => {
+                let reader: Box<dyn InputReader> = if file_size < 1024 * 1024 {
+                    let content = std::fs::read(&path)?;
+                    Box::new(Cursor::new(content))
                 } else {
-                    // Walkdir follow root link only if points to a directory.
-                    // So if it is not a directory, it is a link (no need to handle as a file)
-                    FsEntryKind::Link
-                }
-            } else {
-                FsEntryKind::Link
+                    Box::new(jbk::creator::InputFile::open(&path)?)
+                };
+                let content_address = adder.add_content(reader, jbk::creator::CompHint::Detect)?;
+                FsEntryKind::File(file_size.into(), content_address)
             }
-        } else {
-            FsEntryKind::Other
+            DetectedEntryKind::Link(path) => FsEntryKind::Link(std::fs::read_link(&path)?),
+            DetectedEntryKind::Other => FsEntryKind::Other,
         };
+        log::debug!("{fs_path:?} is dectected as a {kind:?}");
         Ok(Box::new(Self {
             kind,
-            fs_path,
             arx_path,
             #[cfg(unix)]
             uid: attr.uid() as u64,
@@ -89,19 +110,16 @@ impl FsEntry {
 
 impl EntryTrait for FsEntry {
     fn kind(&self) -> jbk::Result<Option<EntryKind>> {
-        Ok(match self.kind {
+        Ok(match &self.kind {
             FsEntryKind::Dir => Some(EntryKind::Dir),
             FsEntryKind::File(size, content_address) => {
-                Some(EntryKind::File(size, content_address))
+                Some(EntryKind::File(*size, *content_address))
             }
 
-            FsEntryKind::Link => {
-                let target = fs::read_link(&self.fs_path)?;
-                Some(EntryKind::Link(BString::from(
-                    Vec::from_path_buf(target)
-                        .unwrap_or_else(|target| panic!("{target:?} must be utf-8")),
-                )))
-            }
+            FsEntryKind::Link(target) => Some(EntryKind::Link(BString::from(
+                Vec::from_path_buf(target.clone())
+                    .unwrap_or_else(|target| panic!("{target:?} must be utf-8")),
+            ))),
             _ => None,
         })
     }
@@ -149,12 +167,15 @@ impl<'a> FsAdder<'a> {
         F: FnMut(&walkdir::DirEntry) -> bool,
         F: Send + 'static,
     {
+        let path = path.as_ref();
+        log::trace!("add_from_path_with_filter(path:{path:?}, recurse:{recurse})");
         let (tx, rx) = mpsc::channel();
-        let path_copy = path.as_ref().to_path_buf();
+        let path_copy = path.to_path_buf();
         let strip_prefix = self.strip_prefix.clone();
 
         spawn(move || {
             let mut walker = walkdir::WalkDir::new(path_copy);
+
             if !recurse {
                 walker = walker.max_depth(0);
             }
@@ -167,7 +188,7 @@ impl<'a> FsAdder<'a> {
 
         while let Ok(entry) = rx.recv() {
             // Walkdir behaves differently if root is a link to a directory
-            let is_root_entry = entry.path() == path.as_ref();
+            let is_root_entry = entry.path() == path;
 
             let entry_path = entry.path();
             let arx_path = match crate::PathBuf::from_path(entry_path) {
@@ -202,8 +223,12 @@ impl<'a> FsAdder<'a> {
                 continue;
             }
 
-            let entry =
-                FsEntry::new_from_walk_entry(entry, arx_path, self.creator.adder(), is_root_entry)?;
+            let entry = FsEntry::new_from_path(
+                entry.path(),
+                arx_path,
+                self.creator.adder(),
+                is_root_entry,
+            )?;
 
             self.creator.add_entry(entry.as_ref())?;
         }


### PR DESCRIPTION
On top of small code improvement/simplification, this PR:

- Detect if there is a inconsistency between files listed in the file list and symlink to directory added as symlink. (Before that, arx was crashing at the end because it cannot sort the entry store).
- Properly handle symlink following (with a new option `--follow-symlink`)
- Add a lot of documentation help on `arx create` sub command.