### PR TITLE
small fixes

### DIFF
--- a/arx/Cargo.toml
+++ b/arx/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 repository.workspace = true
 license.workspace = true
 homepage.workspace = true
+default-run = "arx"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/python/src/arx.rs
+++ b/python/src/arx.rs
@@ -66,7 +66,7 @@ impl Arx {
 #[pymethods]
 impl Arx {
     #[new]
-    fn py_new<'py>(path: Bound<'py, PyUnicode>) -> PyResult<Self> {
+    fn py_new(path: Bound<PyUnicode>) -> PyResult<Self> {
         let path: std::path::PathBuf = path.extract()?;
         match arx::Arx::new(path) {
             Ok(a) => Ok(Self::new(a)),

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn libarx<'py>(_py: Python, m: Bound<'py, PyModule>) -> PyResult<()> {
+fn libarx(_py: Python, m: Bound<PyModule>) -> PyResult<()> {
     m.add_class::<arx::Arx>()?;
     m.add_class::<entry::Entry>()?;
     m.add_class::<content_address::ContentAddress>()?;


### PR DESCRIPTION
- Remove unnecessary lifetime specification in python wrapping.
- Make `arx` the default binary when run from cargo