### PR TITLE
Include git tag in `--version` output.

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -74,6 +74,8 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-tags: true
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
      
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-tags: true
 
     - name: Publish
       env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,8 +162,10 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "color-print",
+ "const_format",
  "daemonize",
  "env_logger",
+ "git-version",
  "human-panic",
  "indicatif",
  "jubako",
@@ -431,6 +433,26 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -740,6 +762,26 @@ name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1777,6 +1819,12 @@ name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unindent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [workspace.dependencies]
 jbk = { git = "https://github.com/jubako/jubako.git", package = "jubako", version = "0.3.2-dev" }
-clap = { version = "4.4.5", features = ["derive"] }
+clap = { version = "4.4.5", features = ["derive", "cargo"] }
 clap_mangen = "0.2.20"
 clap_complete = "4.5.0"
 human-panic = "2.0.1"

--- a/arx/Cargo.toml
+++ b/arx/Cargo.toml
@@ -26,6 +26,8 @@ log = "0.4.20"
 tempfile = "3.10.1"
 libc = "0.2.158"
 color-print = "0.3.7"
+git-version = "0.3.9"
+const_format = "0.2.33"
 
 [target.'cfg(unix)'.dependencies]
 daemonize = "0.5.0"

--- a/arx/src/main.rs
+++ b/arx/src/main.rs
@@ -11,8 +11,14 @@ use clap::{CommandFactory, Parser};
 use log::error;
 use std::process::ExitCode;
 
+const VERSION: &str = const_format::formatcp!(
+    "{} (git:{})",
+    clap::crate_version!(),
+    git_version::git_version!(args = ["--dirty=*", "--tags", "--always"])
+);
+
 #[derive(Parser, Debug)]
-#[command(name = "arx", author, version, about, long_about=None)]
+#[command(name = "arx", author, version, long_version=VERSION, about, long_about=None)]
 struct Cli {
     /// Set verbose level. Can be specify several times to augment verbose level.
     #[arg(short, long, action=clap::ArgAction::Count, global=true)]


### PR DESCRIPTION
Short version (`-V`) is unchanged and displays declared version only.

Fix #42