### PR TITLE
Use `jbk::cmd_utils` instead of `arx::cmd_utils`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ version = "0.3.2-dev"
 dependencies = [
  "blake3",
  "bstr",
+ "clap",
  "crc",
  "deranged",
  "dropout",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/jubako/arx"
 license = "MIT"
 
 [workspace.dependencies]
-jbk = { git = "https://github.com/jubako/jubako.git", package = "jubako", version = "0.3.2-dev" }
+jbk = { git = "https://github.com/jubako/jubako.git", package = "jubako", features = ["clap"], version = "0.3.2-dev" }
 clap = { version = "4.4.5", features = ["derive", "cargo"] }
 clap_mangen = "0.2.20"
 clap_complete = "4.5.0"

--- a/arx/src/create.rs
+++ b/arx/src/create.rs
@@ -146,10 +146,10 @@ pub struct Options {
     no_recurse: bool,
 
     #[command(flatten)]
-    concat_mode: Option<arx::cmd_utils::ConcatMode>,
+    concat_mode: Option<jbk::cmd_utils::ConcatMode>,
 
     /// Set compression algorithm to use
-    #[arg(short,long, value_parser=arx::cmd_utils::compression_arg_parser, required=false, default_value = "zstd")]
+    #[arg(short,long, value_parser=jbk::cmd_utils::compression_arg_parser, required=false, default_value = "zstd")]
     compression: jbk::creator::Compression,
 
     /// List available compression algorithms
@@ -270,7 +270,7 @@ impl CachedSize {
 
 pub fn create(options: Options) -> Result<()> {
     if options.list_compressions {
-        arx::cmd_utils::list_compressions();
+        jbk::cmd_utils::list_compressions();
         return Ok(());
     }
 
@@ -284,6 +284,7 @@ pub fn create(options: Options) -> Result<()> {
     );
     let out_file = std::env::current_dir()?.join(out_file);
     check_output_path_writable(&out_file, options.force)?;
+
     info!("Creating archive {:?}", out_file);
     let file_list = options
         .file_list

--- a/tar2arx/src/main.rs
+++ b/tar2arx/src/main.rs
@@ -28,13 +28,13 @@ struct Cli {
     outfile: Option<PathBuf>,
 
     #[command(flatten)]
-    concat_mode: Option<arx::cmd_utils::ConcatMode>,
+    concat_mode: Option<jbk::cmd_utils::ConcatMode>,
 
     /// Set compression algorithm to use
     #[arg(
         short,
         long,
-        value_parser=arx::cmd_utils::compression_arg_parser,
+        value_parser=jbk::cmd_utils::compression_arg_parser,
         required=false,
         default_value = "zstd"
     )]
@@ -276,7 +276,7 @@ fn main() -> Result<()> {
     let args = Cli::parse();
 
     if args.list_compressions {
-        arx::cmd_utils::list_compressions();
+        jbk::cmd_utils::list_compressions();
         return Ok(());
     }
 

--- a/zip2arx/src/main.rs
+++ b/zip2arx/src/main.rs
@@ -33,7 +33,7 @@ struct Cli {
     outfile: Option<PathBuf>,
 
     #[command(flatten)]
-    concat_mode: Option<arx::cmd_utils::ConcatMode>,
+    concat_mode: Option<jbk::cmd_utils::ConcatMode>,
 
     /// Set compression algorithm to use
     #[arg(
@@ -265,7 +265,7 @@ fn main() -> jbk::Result<()> {
     let args = Cli::parse();
 
     if args.list_compressions {
-        arx::cmd_utils::list_compressions();
+        jbk::cmd_utils::list_compressions();
         return Ok(());
     }
 


### PR DESCRIPTION
We keep `arx::cmd_utils` to not break libarx api but it will be removed soon.