### PR TITLE
Better handle existing files when extracting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Test code
         run: cargo test --workspace --verbose --features in_ci
+        env:
+          RUST_BACKTRACE: 1
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "const_format",
  "daemonize",
  "env_logger",
+ "filetime",
  "format-bytes",
  "git-version",
  "human-panic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arx"
-version = "0.3.2"
+version = "0.4.0-dev.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1090,7 +1090,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libarx"
-version = "0.3.2"
+version = "0.4.0-dev.0"
 dependencies = [
  "blake3",
  "bstr",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "python-libarx"
-version = "0.3.2"
+version = "0.4.0-dev.0"
 dependencies = [
  "jubako",
  "libarx",
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "tar2arx"
-version = "0.3.2"
+version = "0.4.0-dev.0"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "zip2arx"
-version = "0.3.2"
+version = "0.4.0-dev.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/arx/Cargo.toml
+++ b/arx/Cargo.toml
@@ -38,6 +38,7 @@ rand = { version = "0.8.5", features = ["small_rng"]}
 lipsum = "0.9.0"
 tempfile = "3.8.0"
 format-bytes = "0.3.0"
+filetime = "0.2.25"
 
 [features]
 default = ["zstd", "fuse"]

--- a/arx/src/bin/auto_mount.rs
+++ b/arx/src/bin/auto_mount.rs
@@ -34,7 +34,6 @@ mod inner {
 #[cfg(unix)]
 fn main() -> ExitCode {
     use inner::*;
-    use log::{error, info};
 
     human_panic::setup_panic!(human_panic::Metadata::new(
         env!("CARGO_PKG_NAME"),
@@ -46,18 +45,18 @@ fn main() -> ExitCode {
     match env::current_exe() {
         Ok(exe_path) => {
             if args.verbose > 0 {
-                info!("Auto Mount archive {:?} in {:?}", exe_path, args.mountdir);
+                print!("Auto Mount archive {:?} in {:?}", exe_path, args.mountdir);
             }
             match mount(exe_path, args.mountdir) {
                 Ok(()) => ExitCode::SUCCESS,
                 Err(e) => match e.error {
                     jbk::ErrorKind::NotAJbk => {
-                        error!("Impossible to locate a Jubako archive in the executable.");
-                        error!("This binary is not intented to be directly used, you must put a Jubako archive at its end.");
+                        eprintln!("Impossible to locate a Jubako archive in the executable.");
+                        eprintln!("This binary is not intented to be directly used, you must put a Jubako archive at its end.");
                         ExitCode::FAILURE
                     }
                     _ => {
-                        error!("Error: {e}");
+                        eprintln!("Error: {e}");
                         ExitCode::FAILURE
                     }
                 },

--- a/arx/src/bin/mount_fuse_arx.rs
+++ b/arx/src/bin/mount_fuse_arx.rs
@@ -33,7 +33,6 @@ mod inner {
 #[cfg(unix)]
 fn main() -> jbk::Result<()> {
     use inner::*;
-    use log::error;
 
     human_panic::setup_panic!(human_panic::Metadata::new(
         env!("CARGO_PKG_NAME"),
@@ -43,7 +42,7 @@ fn main() -> jbk::Result<()> {
     let args = Cli::parse();
 
     if args.option.contains(&"rw".into()) {
-        error!("arx cannot be mounted rw");
+        eprintln!("arx cannot be mounted rw");
         return Err("arx cannot be mounted rw".into());
     }
 

--- a/arx/src/extract.rs
+++ b/arx/src/extract.rs
@@ -70,6 +70,9 @@ pub struct Options {
         required_unless_present("infile")
     )]
     infile_old: Option<PathBuf>,
+
+    #[arg(long, default_value = "warn")]
+    overwrite: arx::Overwrite,
 }
 
 fn get_files_to_extract(options: &Options) -> jbk::Result<HashSet<arx::PathBuf>> {
@@ -108,6 +111,7 @@ pub fn extract(options: Options) -> anyhow::Result<()> {
             files_to_extract,
             options.recurse,
             options.progress,
+            options.overwrite,
         )?,
         Some(p) => {
             let relative_path = arx::Path::from_path(&p)?;
@@ -120,6 +124,7 @@ pub fn extract(options: Options) -> anyhow::Result<()> {
                     files_to_extract,
                     options.recurse,
                     options.progress,
+                    options.overwrite,
                 )?,
                 _ => return Err(anyhow::anyhow!("{} must be a directory", p.display())),
             }

--- a/arx/src/main.rs
+++ b/arx/src/main.rs
@@ -8,7 +8,6 @@ mod mount;
 
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
-use log::error;
 use std::process::ExitCode;
 
 const VERSION: &str = const_format::formatcp!(
@@ -146,7 +145,7 @@ fn main() -> ExitCode {
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
-            error!("Error : {e:#}");
+            eprintln!("Error : {e:#}");
             ExitCode::FAILURE
         }
     }

--- a/arx/tests/create.rs
+++ b/arx/tests/create.rs
@@ -9,7 +9,7 @@ fn test_crate_non_existant_input() -> Result {
     temp_arx!(arx_file);
     cmd!("arx", "create", "--outfile", &arx_file, "non_existant_dir").check_fail(
         b"",
-        b"[ERROR arx] Error : Input non_existant_dir path doesn't exist or cannot be accessed\n",
+        b"Error : Input non_existant_dir path doesn't exist or cannot be accessed\n",
     );
     assert!(!arx_file.exists());
     Ok(())
@@ -33,7 +33,7 @@ fn test_crate_non_existant_output_directory() -> Result {
     .check_fail(
         b"",
         &format_bytes!(
-            b"[ERROR arx] Error : Directory {} doesn't exist\n",
+            b"Error : Directory {} doesn't exist\n",
             arx_file.parent().unwrap().as_os_str().as_encoded_bytes()
         ),
     );
@@ -66,7 +66,7 @@ fn test_crate_existant_output() -> Result {
     .check_fail(
         b"",
         &format_bytes!(
-            b"[ERROR arx] Error : File {} already exists. Use option --force to overwrite it.\n",
+            b"Error : File {} already exists. Use option --force to overwrite it.\n",
             arx_file.as_os_str().as_encoded_bytes()
         ),
     );

--- a/arx/tests/create.rs
+++ b/arx/tests/create.rs
@@ -85,7 +85,7 @@ fn test_crate_existant_output() -> Result {
         tmp_source_dir.file_name().unwrap(),
         "--force"
     )
-    .check_output(b"", b"");
+    .check_output(Some(b""), Some(b""));
     {
         let mut f = std::fs::File::open(&arx_file)?;
         let mut buf = [0; 10];

--- a/arx/tests/extract_mount.rs
+++ b/arx/tests/extract_mount.rs
@@ -42,7 +42,7 @@ pub static BASE_ARX_FILE: LazyLock<TmpArx> = LazyLock::new(|| {
         source_dir.file_name().unwrap(),
         source_dir.file_name().unwrap()
     )
-    .check_output(b"", b"");
+    .check_output(Some(b""), Some(b""));
     TmpArx::new(tmp_arx_dir, tmp_arx)
 });
 
@@ -120,7 +120,7 @@ fn test_extract_subdir() -> Result {
         "-C",
         extract_dir.path()
     )
-    .check_output(b"", b"");
+    .check_output(Some(b""), Some(b""));
 
     let source_sub_dir = join!(tmp_source_dir / "sub_dir_a");
 
@@ -167,7 +167,7 @@ fn test_extract_existing_content_skip() -> Result {
         extract_dir.path(),
         "--overwrite=skip"
     )
-    .check_output(b"", b"");
+    .check_output(Some(b""), Some(b""));
     assert!(tree_diff(
         extract_dir,
         tmp_source_dir,
@@ -197,14 +197,14 @@ fn test_extract_existing_content_warn() -> Result {
         "--overwrite=warn"
     )
     .check_output(
-        b"",
-        &format_bytes!(
+        Some(b""),
+        Some(&format_bytes!(
             b"File {} already exists.\n",
             join!(extract_dir / "sub_dir_a" / "existing_file")
                 .to_str()
                 .unwrap()
                 .as_bytes()
-        ),
+        )),
     );
     assert!(tree_diff(
         extract_dir,
@@ -239,7 +239,7 @@ fn test_extract_existing_content_newer_true() -> Result {
         extract_dir.path(),
         "--overwrite=newer"
     )
-    .check_output(b"", b"");
+    .check_output(Some(b""), Some(b""));
     assert!(tree_diff(extract_dir, tmp_source_dir, Default::default())?);
     Ok(())
 }
@@ -266,7 +266,7 @@ fn test_extract_existing_content_newer_false() -> Result {
         extract_dir.path(),
         "--overwrite=newer"
     )
-    .check_output(b"", b"");
+    .check_output(Some(b""), Some(b""));
     assert!(tree_diff(
         extract_dir,
         tmp_source_dir,
@@ -294,7 +294,7 @@ fn test_extract_existing_content_overwrite() -> Result {
         extract_dir.path(),
         "--overwrite=overwrite"
     )
-    .check_output(b"", b"");
+    .check_output(Some(b""), Some(b""));
     assert!(tree_diff(extract_dir, tmp_source_dir, Default::default())?);
     Ok(())
 }

--- a/arx/tests/extract_mount.rs
+++ b/arx/tests/extract_mount.rs
@@ -138,10 +138,7 @@ fn test_extract_subfile() -> Result {
         "-C",
         extract_dir.path()
     )
-    .check_fail(
-        b"",
-        b"[ERROR arx] Error : sub_dir_a/file1.txt must be a directory\n",
-    );
+    .check_fail(b"", b"Error : sub_dir_a/file1.txt must be a directory\n");
     Ok(())
 }
 
@@ -303,7 +300,7 @@ fn test_extract_existing_content_error() -> Result {
     .check_fail(
         b"",
         &format_bytes!(
-            b"[ERROR arx] Error : Unknown error : File {} already exists.\n",
+            b"Error : Unknown error : File {} already exists.\n",
             join!((extract_dir.path()) / "sub_dir_a" / "file1.txt")
                 .to_str()
                 .unwrap()

--- a/arx/tests/extract_mount.rs
+++ b/arx/tests/extract_mount.rs
@@ -80,6 +80,20 @@ fn test_extract() -> Result {
 }
 
 #[test]
+fn test_extract_same_dir() -> Result {
+    // This test that everything go "fine" when extracting an archive in the source directory.
+    // But here we don't want to take the risk to polute our source directory shared with other tests.
+    // So we extract twice the same archive in the same place.
+
+    let arx_file = BASE_ARX_FILE.path();
+
+    let extract_dir = tempfile::TempDir::with_prefix_in("extract_", env!("CARGO_TARGET_TMPDIR"))?;
+    cmd!("arx", "extract", &arx_file, "-C", extract_dir.path()).check_output(Some(b""), Some(b""));
+    cmd!("arx", "extract", &arx_file, "-C", extract_dir.path()).check_output(Some(b""), None);
+    Ok(())
+}
+
+#[test]
 fn test_extract_filter() -> Result {
     let tmp_source_dir = SHARED_TEST_DIR.path();
     let arx_file = BASE_ARX_FILE.path();

--- a/arx/tests/extract_mount.rs
+++ b/arx/tests/extract_mount.rs
@@ -93,7 +93,7 @@ fn test_extract_filter() -> Result {
     )?;
 
     let source_sub_dir = join!(tmp_source_dir / "sub_dir_a");
-    let extract_sub_dir = join!((extract_dir.path()) / "sub_dir_a");
+    let extract_sub_dir = join!(extract_dir / "sub_dir_a");
 
     assert!(tree_equal(source_sub_dir, extract_sub_dir)?);
     Ok(())
@@ -189,7 +189,7 @@ fn test_extract_existing_content_warn() -> Result {
         b"",
         &format_bytes!(
             b"File {} already exists.\n",
-            join!((extract_dir.path()) / "sub_dir_a" / "file1.txt")
+            join!(extract_dir / "sub_dir_a" / "file1.txt")
                 .to_str()
                 .unwrap()
                 .as_bytes()
@@ -212,7 +212,7 @@ fn test_extract_existing_content_newer_true() -> Result {
 
     // File is modified far before arx created, so we should overwrite
     filetime::set_file_mtime(
-        join!((extract_dir.path()) / "sub_dir_a" / "file1.txt"),
+        join!(extract_dir / "sub_dir_a" / "file1.txt"),
         filetime::FileTime::from_unix_time(0, 0),
     )?;
 
@@ -301,7 +301,7 @@ fn test_extract_existing_content_error() -> Result {
         b"",
         &format_bytes!(
             b"Error : Unknown error : File {} already exists.\n",
-            join!((extract_dir.path()) / "sub_dir_a" / "file1.txt")
+            join!(extract_dir / "sub_dir_a" / "file1.txt")
                 .to_str()
                 .unwrap()
                 .as_bytes()

--- a/arx/tests/extract_mount.rs
+++ b/arx/tests/extract_mount.rs
@@ -41,7 +41,7 @@ pub static BASE_ARX_FILE: LazyLock<TmpArx> = LazyLock::new(|| {
         source_dir.file_name().unwrap(),
         source_dir.file_name().unwrap()
     )
-    .check();
+    .check_output(b"", b"");
     TmpArx::new(tmp_arx_dir, tmp_arx)
 });
 

--- a/arx/tests/utils/mod.rs
+++ b/arx/tests/utils/mod.rs
@@ -5,7 +5,7 @@ use rand::prelude::*;
 pub type Result = anyhow::Result<()>;
 
 #[allow(unused_imports)]
-pub use tree_diff::tree_diff;
+pub use tree_diff::{tree_diff, ExistingExpected};
 
 #[cfg(unix)]
 pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(path: P, target: Q) -> std::io::Result<()> {
@@ -240,6 +240,7 @@ pub static SHARED_TEST_DIR: LazyLock<tempfile::TempDir> = LazyLock::new(|| {
         Ok(temp_tree!(1, {
             dir "sub_dir_a" {
                 text "existing_file" 50,
+                link "existing_link" -> "existing_file",
                 text "file_2.txt" (500..1000),
                 loop  (10..50) { text "file{ctx}.txt" (500..1000) }
             },

--- a/arx/tests/utils/mod.rs
+++ b/arx/tests/utils/mod.rs
@@ -1,7 +1,11 @@
+mod tree_diff;
 use std::{io::Read, path::Path, process::Command, sync::LazyLock};
 
 use rand::prelude::*;
 pub type Result = anyhow::Result<()>;
+
+#[allow(unused_imports)]
+pub use tree_diff::tree_diff;
 
 #[cfg(unix)]
 pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(path: P, target: Q) -> std::io::Result<()> {
@@ -235,6 +239,7 @@ pub static SHARED_TEST_DIR: LazyLock<tempfile::TempDir> = LazyLock::new(|| {
     (|| -> std::io::Result<tempfile::TempDir> {
         Ok(temp_tree!(1, {
             dir "sub_dir_a" {
+                text "existing_file" 50,
                 text "file_2.txt" (500..1000),
                 loop  (10..50) { text "file{ctx}.txt" (500..1000) }
             },
@@ -309,24 +314,6 @@ macro_rules! temp_arx {
             .expect("Creating tmpdir should work");
         let $name = tmp_arx_dir.path().join($filename);
     };
-}
-
-#[allow(dead_code)]
-pub fn tree_equal<P: AsRef<Path>, Q: AsRef<Path>>(a: P, b: Q) -> anyhow::Result<bool> {
-    let a = a.as_ref();
-    let b = b.as_ref();
-    let output = run!(output, "diff", "-r", a, b);
-    if output.status.success() {
-        Ok(true)
-    } else {
-        println!(
-            "Diff failed between {a} and {b}:\n{err}",
-            a = a.display(),
-            b = b.display(),
-            err = String::from_utf8_lossy(&output.stdout)
-        );
-        Ok(false)
-    }
 }
 
 #[allow(dead_code)]

--- a/arx/tests/utils/mod.rs
+++ b/arx/tests/utils/mod.rs
@@ -386,11 +386,15 @@ impl CheckCommand for Command {
 #[macro_export]
 macro_rules! join {
     ($first:tt / $($args:tt)/+) => {
+        join!(@init, $first, $($args),+)
+    };
+    (@init, $first:expr, $($args:tt),+) => {
         {
-            let mut path = $first.to_path_buf();
+            let mut path:PathBuf = AsRef::<Path>::as_ref(&$first).to_path_buf();
             join!(@append, path, $($args),+);
             path
         }
+
     };
     (@append, $path:ident, $args:expr) => {
         $path.push($args);

--- a/arx/tests/utils/mod.rs
+++ b/arx/tests/utils/mod.rs
@@ -252,7 +252,7 @@ pub static SHARED_TEST_DIR: LazyLock<tempfile::TempDir> = LazyLock::new(|| {
             }
         }))
     })()
-    .unwrap()
+    .expect("Error creating the directory tree")
 });
 
 #[macro_export]

--- a/arx/tests/utils/tree_diff.rs
+++ b/arx/tests/utils/tree_diff.rs
@@ -1,0 +1,273 @@
+#![allow(dead_code)]
+
+use std::{
+    cmp::Ordering,
+    collections::{BTreeSet, HashMap},
+    ffi::OsStr,
+    fs::{read_dir, read_link, symlink_metadata, File, ReadDir},
+    io::{self, BufReader, Read},
+    ops::Deref,
+    path::{Path, PathBuf},
+};
+
+struct ReadAsIter<R: Read>(BufReader<R>);
+
+impl<R: Read> Iterator for ReadAsIter<R> {
+    type Item = u8;
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut result: [u8; 1] = [0; 1];
+        match self.0.read(&mut result).expect("read should succeed") {
+            0 => None,
+            1 => Some(result[0]),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<R: Read> From<R> for ReadAsIter<R> {
+    fn from(value: R) -> Self {
+        Self(BufReader::new(value))
+    }
+}
+
+#[derive(Debug)]
+enum Entry {
+    Dir(PathBuf),
+    File(PathBuf),
+    Link(PathBuf),
+}
+
+impl Entry {
+    fn new(p: &Path) -> io::Result<Self> {
+        let metadata = symlink_metadata(p)?;
+        if metadata.is_dir() {
+            Ok(Self::Dir(p.to_path_buf()))
+        } else if metadata.is_file() {
+            Ok(Self::File(p.to_path_buf()))
+        } else if metadata.is_symlink() {
+            Ok(Self::File(p.to_path_buf()))
+        } else {
+            unreachable!()
+        }
+    }
+
+    fn path(&self) -> &Path {
+        match self {
+            Entry::Dir(p) => p,
+            Entry::File(p) => p,
+            Entry::Link(p) => p,
+        }
+    }
+
+    fn file_name(&self) -> &OsStr {
+        self.path().file_name().unwrap()
+    }
+}
+
+impl PartialEq for Entry {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Entry::File(a), Entry::File(b)) => {
+                let file_a: ReadAsIter<_> = File::open(a).expect("Open should succeed").into();
+                let file_b: ReadAsIter<_> = File::open(b).expect("Open should succeed").into();
+                file_a.cmp(file_b) == Ordering::Equal
+            }
+            (Entry::Link(a), Entry::Link(b)) => {
+                let target_a = read_link(a).expect("Read_link should succeed");
+                let target_b = read_link(b).expect("Read_link should succeed");
+                target_a.cmp(&target_b) == Ordering::Equal
+            }
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct OrderByPath(Entry);
+
+impl OrderByPath {
+    fn key(&self) -> &OsStr {
+        self.0.file_name()
+    }
+}
+
+impl Eq for OrderByPath {}
+
+impl Ord for OrderByPath {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.key().cmp(other.key())
+    }
+}
+
+impl PartialOrd for OrderByPath {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.key().partial_cmp(other.key())
+    }
+}
+
+impl PartialEq for OrderByPath {
+    fn eq(&self, other: &Self) -> bool {
+        self.key() == other.key()
+    }
+}
+
+impl Deref for OrderByPath {
+    type Target = Entry;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+struct EntryIterator(ReadDir);
+
+impl EntryIterator {
+    fn new(p: &Path) -> Self {
+        Self(read_dir(p).unwrap())
+    }
+}
+
+impl Iterator for EntryIterator {
+    type Item = OrderByPath;
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.0.next()?.expect("Iter dir should succeed");
+        let file_type = next.file_type().unwrap();
+        Some(OrderByPath(if file_type.is_dir() {
+            Entry::Dir(next.path())
+        } else if file_type.is_file() {
+            Entry::File(next.path())
+        } else if file_type.is_symlink() {
+            Entry::Link(next.path())
+        } else {
+            unreachable!()
+        }))
+    }
+}
+
+struct ExceptionMatcher {
+    current_path: PathBuf,
+    exceptions: HashMap<PathBuf, Option<Vec<u8>>>,
+    equal: bool,
+}
+
+impl ExceptionMatcher {
+    fn new(exceptions: HashMap<PathBuf, Option<Vec<u8>>>) -> Self {
+        Self {
+            current_path: PathBuf::new(),
+            exceptions,
+            equal: true,
+        }
+    }
+
+    fn result(self) -> bool {
+        self.equal
+    }
+
+    fn push(&mut self, entry_name: &OsStr) {
+        self.current_path.push(entry_name);
+    }
+
+    fn pop(&mut self) {
+        self.current_path.pop();
+    }
+
+    fn added(&mut self, entry: &Entry) {
+        println!(
+            "Added {} in {}",
+            entry.path().display(),
+            self.current_path.display()
+        );
+        self.equal = false;
+    }
+
+    fn removed(&mut self, entry: &Entry) {
+        println!(
+            "Removed {} in {}",
+            entry.path().display(),
+            self.current_path.display()
+        );
+        self.equal = false;
+    }
+
+    fn diff(&mut self, entry_tested: &Entry, entry_ref: &Entry) {
+        match self.exceptions.get(&self.current_path) {
+            None => {
+                println!(
+                    "Entry {} is different than {}",
+                    entry_tested.path().display(),
+                    entry_ref.path().display()
+                );
+                self.equal = false;
+            }
+            Some(None) => {
+                //Nothing to do
+            }
+            Some(Some(expected)) => {
+                let found_content = std::fs::read(entry_tested.path()).unwrap();
+                if found_content != *expected {
+                    println!(
+                        "Entry {} is different than expected content",
+                        entry_tested.path().display()
+                    );
+                    self.equal = false;
+                }
+            }
+        }
+    }
+}
+
+fn diff(tested: &Entry, reference: &Entry, matcher: &mut ExceptionMatcher) {
+    match (tested, reference) {
+        // two files or links, equal
+        (Entry::File(_), Entry::File(_)) if tested == reference => {}
+        (Entry::Link(_), Entry::Link(_)) if tested == reference => {}
+
+        // Directories, we must compare
+        (Entry::Dir(path_tested), Entry::Dir(path_ref)) => {
+            let children_tested = EntryIterator::new(&path_tested).collect::<BTreeSet<_>>();
+            let children_ref = EntryIterator::new(&path_ref).collect::<BTreeSet<_>>();
+            for v_tested in children_tested.intersection(&children_ref) {
+                let v_ref = children_ref.get(v_tested).expect("intersection to work");
+                matcher.push(v_tested.file_name());
+                diff(&v_tested, &v_ref, matcher);
+                matcher.pop();
+            }
+            for k in children_tested.difference(&children_ref) {
+                matcher.added(k);
+            }
+            for k in children_ref.difference(&children_tested) {
+                matcher.removed(k);
+            }
+        }
+
+        // Different
+        _ => matcher.diff(tested, reference),
+    }
+}
+
+/// Compare two paths and return true if they are identical.
+/// Identical means:
+/// - Same kind
+/// - Same content for files
+/// - Same target for symlink
+/// - Same entries for directory
+///
+/// `exceptions` is a HashMap of entry than can differ from source.
+/// If value in the hashmap is `None`, we accept different content all the time.
+/// If value is `Some(content)`, the content of the file must match `content`.
+///
+/// Please note that tested (generated by thing being tested) content comes first and
+/// reference second. This is important when `exceptions` has values as we will load
+/// file content in first (tested) tree.
+pub fn tree_diff(
+    tested: impl AsRef<Path>,
+    reference: impl AsRef<Path>,
+    exceptions: HashMap<PathBuf, Option<Vec<u8>>>,
+) -> std::io::Result<bool> {
+    let mut matcher = ExceptionMatcher::new(exceptions);
+    diff(
+        &Entry::new(tested.as_ref())?,
+        &Entry::new(reference.as_ref())?,
+        &mut matcher,
+    );
+    Ok(matcher.result())
+}

--- a/libarx/src/lib.rs
+++ b/libarx/src/lib.rs
@@ -19,5 +19,5 @@ pub use common::{
     PathBuf, VENDOR_ID,
 };
 pub use entry::*;
-pub use tools::{extract, extract_arx, extract_arx_range};
+pub use tools::{extract, extract_arx, extract_arx_range, Overwrite};
 pub use walk::*;

--- a/libarx/src/tools.rs
+++ b/libarx/src/tools.rs
@@ -1,11 +1,14 @@
 use std::collections::HashSet;
 use std::fs::{create_dir, create_dir_all, OpenOptions};
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
 #[cfg(windows)]
 use std::os::windows::fs::symlink_file as symlink;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
 use crate::{AllProperties, Arx, Builder, Walker};
 use jbk::reader::builder::PropertyBuilderTrait;
@@ -15,6 +18,7 @@ use jbk::reader::MayMissPack;
 struct FileEntry {
     path: String,
     content: jbk::ContentAddress,
+    mtime: u64,
 }
 
 struct Link {
@@ -25,6 +29,7 @@ struct Link {
 struct FileBuilder {
     path_property: jbk::reader::builder::ArrayProperty,
     content_address_property: jbk::reader::builder::ContentProperty,
+    mtime_property: jbk::reader::builder::IntProperty,
 }
 
 impl Builder for FileBuilder {
@@ -34,6 +39,7 @@ impl Builder for FileBuilder {
         Self {
             path_property: properties.path_property.clone(),
             content_address_property: properties.file_content_address_property,
+            mtime_property: properties.mtime_property.clone(),
         }
     }
 
@@ -42,9 +48,11 @@ impl Builder for FileBuilder {
         let mut path = vec![];
         path_prop.resolve_to_vec(&mut path)?;
         let content = self.content_address_property.create(reader)?;
+        let mtime = self.mtime_property.create(reader)?;
         Ok(FileEntry {
             path: String::from_utf8(path)?,
             content,
+            mtime,
         })
     }
 }
@@ -102,6 +110,16 @@ impl Builder for DirBuilder {
 
 type FullBuilder = (FileBuilder, LinkBuilder, DirBuilder);
 
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "cmd_utils", derive(clap::ValueEnum))]
+pub enum Overwrite {
+    Skip,
+    Warn,
+    Newer,
+    Overwrite,
+    Error,
+}
+
 struct Extractor<'a, 'scope>
 where
     'a: 'scope,
@@ -112,6 +130,8 @@ where
     base_dir: PathBuf,
     print_progress: bool,
     recurse: bool,
+    extract_ok: Arc<AtomicBool>,
+    overwrite: Overwrite,
 }
 
 impl Extractor<'_, '_> {
@@ -205,45 +225,88 @@ where
             return Ok(());
         }
         let bytes = arx.container.get_bytes(entry_content).unwrap();
+        let extract_ok = Arc::clone(&self.extract_ok);
 
-        self.scope.spawn(move |_scope| {
-            match bytes {
-                MayMissPack::FOUND(bytes) => {
-                    let abs_path = abs_path.clone();
-                    let mut file = OpenOptions::new()
-                        .write(true)
-                        .create_new(true)
-                        .open(abs_path)
-                        .unwrap();
+        match bytes {
+            MayMissPack::FOUND(bytes) => {
+                let abs_path = abs_path.clone();
+                let mut file = match OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&abs_path)
+                {
+                    Ok(f) => f,
+                    Err(e) => match e.kind() {
+                        ErrorKind::AlreadyExists => match self.overwrite {
+                            Overwrite::Skip => return Ok(()),
+                            Overwrite::Warn => {
+                                eprintln!("File {} already exists.", abs_path.display());
+                                return Ok(());
+                            }
+                            Overwrite::Newer => {
+                                let existing_metadata = std::fs::metadata(&abs_path)?;
+                                let existing_time = existing_metadata.modified()?;
+                                let new_time =
+                                    SystemTime::UNIX_EPOCH + Duration::from_secs(entry.mtime);
+                                if new_time >= existing_time {
+                                    OpenOptions::new()
+                                        .write(true)
+                                        .truncate(true)
+                                        .open(&abs_path)?
+                                } else {
+                                    return Ok(());
+                                }
+                            }
+                            Overwrite::Overwrite => OpenOptions::new()
+                                .write(true)
+                                .truncate(true)
+                                .open(&abs_path)?,
+                            Overwrite::Error => {
+                                return Err(
+                                    format!("File {} already exists.", abs_path.display()).into()
+                                );
+                            }
+                        },
+                        _ => return Err(e.into()),
+                    },
+                };
 
+                self.scope.spawn(move |_scope| {
                     // Don't use std::io::copy as it use an internal buffer where it read data into before writing in file.
                     // If content is compressed, we already have a buffer. Same thing for uncompress as the cluster is probably mmapped.
                     let size = bytes.size().into_u64();
                     let mut offset = 0;
-                    loop {
-                        let sub_size = std::cmp::min(size - offset, 4 * 1024) as usize;
-                        let written = file
-                            .write(&bytes.get_slice(offset.into(), sub_size).unwrap())
-                            .unwrap();
-                        offset += written as u64;
-                        if offset == size {
-                            break;
+                    let mut write_function = move || -> jbk::Result<()> {
+                        loop {
+                            let sub_size = std::cmp::min(size - offset, 4 * 1024) as usize;
+                            let written = file.write(&bytes.get_slice(offset.into(), sub_size)?)?;
+                            offset += written as u64;
+                            if offset == size {
+                                break;
+                            }
                         }
+                        Ok(())
+                    };
+                    if let Err(e) = write_function() {
+                        log::error!("Error writing content to {} : {}", abs_path.display(), e);
+                        extract_ok.store(false, std::sync::atomic::Ordering::Relaxed);
                     }
-                }
-                MayMissPack::MISSING(pack_info) => {
-                    eprintln!(
-                        "Missing pack {} for {}. Declared location is {}",
-                        pack_info.uuid,
-                        abs_path.display(),
-                        String::from_utf8_lossy(&pack_info.pack_location)
-                    );
-                }
+                });
             }
-            if print_progress {
-                println!("{}", abs_path.display());
+            MayMissPack::MISSING(pack_info) => {
+                log::error!(
+                    "Missing pack {} for {}. Declared location is {}",
+                    pack_info.uuid,
+                    abs_path.display(),
+                    String::from_utf8_lossy(&pack_info.pack_location)
+                );
             }
-        });
+        }
+
+        if print_progress {
+            println!("{}", abs_path.display());
+        }
+
         Ok(())
     }
     fn on_link(&self, current_path: &mut crate::PathBuf, link: &Link) -> jbk::Result<()> {
@@ -268,9 +331,10 @@ pub fn extract(
     files_to_extract: HashSet<crate::PathBuf>,
     recurse: bool,
     progress: bool,
+    overwrite: Overwrite,
 ) -> jbk::Result<()> {
     let arx = Arx::new(infile)?;
-    extract_arx(&arx, outdir, files_to_extract, recurse, progress)
+    extract_arx(&arx, outdir, files_to_extract, recurse, progress, overwrite)
 }
 
 pub fn extract_arx(
@@ -279,8 +343,10 @@ pub fn extract_arx(
     files_to_extract: HashSet<crate::PathBuf>,
     recurse: bool,
     progress: bool,
+    overwrite: Overwrite,
 ) -> jbk::Result<()> {
     let mut walker = Walker::new(arx, Default::default());
+    let extract_ok = Arc::new(AtomicBool::new(true));
     rayon::scope(|scope| {
         let extractor = Extractor {
             arx,
@@ -288,10 +354,17 @@ pub fn extract_arx(
             files: files_to_extract,
             base_dir: outdir.to_path_buf(),
             print_progress: progress,
+            extract_ok: Arc::clone(&extract_ok),
             recurse,
+            overwrite,
         };
         walker.run(&extractor)
-    })
+    })?;
+    if !extract_ok.load(std::sync::atomic::Ordering::Relaxed) {
+        Err("Some errors appends during extraction.".to_owned().into())
+    } else {
+        Ok(())
+    }
 }
 
 pub fn extract_arx_range<R: jbk::reader::Range + Sync>(
@@ -301,8 +374,10 @@ pub fn extract_arx_range<R: jbk::reader::Range + Sync>(
     files_to_extract: HashSet<crate::PathBuf>,
     recurse: bool,
     progress: bool,
+    overwrite: Overwrite,
 ) -> jbk::Result<()> {
     let mut walker = Walker::new(arx, Default::default());
+    let extract_ok = Arc::new(AtomicBool::new(true));
     rayon::scope(|scope| {
         let extractor = Extractor {
             arx,
@@ -310,8 +385,15 @@ pub fn extract_arx_range<R: jbk::reader::Range + Sync>(
             files: files_to_extract,
             base_dir: outdir.to_path_buf(),
             print_progress: progress,
+            extract_ok: Arc::clone(&extract_ok),
             recurse,
+            overwrite,
         };
         walker.run_from_range(&extractor, range)
-    })
+    })?;
+    if !extract_ok.load(std::sync::atomic::Ordering::Relaxed) {
+        Err("Some errors appends during extraction.".to_owned().into())
+    } else {
+        Ok(())
+    }
 }

--- a/python/src/arx.rs
+++ b/python/src/arx.rs
@@ -106,7 +106,14 @@ impl Arx {
     /// Extract the whole archive in
     #[pyo3(signature=(extract_path=std::path::PathBuf::from(".")))]
     fn extract(&self, extract_path: std::path::PathBuf) -> PyResult<()> {
-        arx::extract_arx(&self.0, &extract_path, Default::default(), true, false)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+        arx::extract_arx(
+            &self.0,
+            &extract_path,
+            Default::default(),
+            true,
+            false,
+            arx::Overwrite::Warn,
+        )
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 }


### PR DESCRIPTION
- Better error message
- New option `--overwrite` to specify how to overwrite (or not) existing files.

This is a long PR to fix #88 