### PR TITLE
fix(warning): Be explicit about returned struct lifetime.

### DIFF
--- a/libarx/src/common/mod.rs
+++ b/libarx/src/common/mod.rs
@@ -31,7 +31,7 @@ impl Comparator {
         }
     }
 
-    pub fn compare_with<'a>(&'a self, component: &'a [u8]) -> EntryCompare {
+    pub fn compare_with<'a>(&'a self, component: &'a [u8]) -> EntryCompare<'a> {
         EntryCompare {
             comparator: self,
             path_value: component,


### PR DESCRIPTION
Fix #97