### PR TITLE
refactor!: Update Jbk and use error_set for our errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arbitrary"
@@ -205,9 +205,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "blake3"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
+checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.0"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
  "jobserver",
  "libc",
@@ -294,9 +294,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.38"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9647a559c112175f17cf724dc72d3645680a883c58481332779192b0d8e7a01"
+checksum = "ac2e663e3e3bed2d32d065a8404024dad306e699a04263ec59919529f803aee9"
 dependencies = [
  "clap",
 ]
@@ -356,14 +356,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clap_mangen"
@@ -393,7 +393,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -404,31 +404,31 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width 0.1.14",
- "windows-sys 0.52.0",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "const_format"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
 dependencies = [
  "const_format_proc_macros",
 ]
 
 [[package]]
 name = "const_format_proc_macros"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -482,18 +482,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -556,7 +556,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -578,7 +578,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -598,15 +598,15 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -642,19 +642,19 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
@@ -680,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "form_urlencoded"
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "fuser"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e469ac6d2cdfaeb56c5ede4dc00d8a24a4267d5eab9ab365ee783179087ab2e3"
+checksum = "53274f494609e77794b627b1a3cddfe45d675a6b2e9ba9c0fdc8d8eee2184369"
 dependencies = [
  "libc",
  "log",
@@ -726,7 +726,7 @@ dependencies = [
  "page_size",
  "pkg-config",
  "smallvec",
- "zerocopy 0.8.10",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -782,14 +782,14 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -971,7 +971,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1014,7 +1014,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width",
  "web-time",
 ]
 
@@ -1050,20 +1050,19 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jubako"
-version = "0.3.3"
-source = "git+https://github.com/jubako/jubako.git#41999616b48a78a2910ac5eff077bf454a3e6920"
+version = "0.4.0-dev"
 dependencies = [
  "blake3",
- "bstr",
  "clap",
  "crc",
  "deranged",
@@ -1077,17 +1076,12 @@ dependencies = [
  "rayon",
  "spmc",
  "tempfile",
+ "thiserror 2.0.9",
  "uuid",
  "xz2",
  "zerocopy 0.7.35",
  "zstd 0.13.2",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libarx"
@@ -1106,14 +1100,15 @@ dependencies = [
  "rayon",
  "relative-path",
  "tempfile",
+ "thiserror 1.0.69",
  "walkdir",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libredox"
@@ -1144,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lockfree-object-pool"
@@ -1241,9 +1236,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
 ]
@@ -1308,9 +1303,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -1323,9 +1318,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "os_info"
-version = "3.8.2"
+version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
+checksum = "6e6520c8cc998c5741ee68ec1dc369fc47e5f0ea5320018ecf2a1ccd6328f48b"
 dependencies = [
  "log",
  "serde",
@@ -1344,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "pathdiff"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pbkdf2"
@@ -1372,9 +1367,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "portable-atomic"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "powerfmt"
@@ -1402,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebb0c0cc0de9678e53be9ccf8a2ab53045e6e3a8be03393ceccc5e7396ccb40"
+checksum = "e484fd2c8b4cb67ab05a318f1fd6fa8f199fcc30819f08f07d200809dba26c15"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -1420,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e3ce69c4ec34476534b490e412b871ba03a82e35604c3dfb95fcb6bfb60c09"
+checksum = "dc0e0469a84f208e20044b98965e1561028180219e35352a2afaf2b942beff3b"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1430,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09f311c76b36dfd6dd6f7fa6f9f18e7e46a1c937110d283e80b12ba2468a75"
+checksum = "eb1547a7f9966f6f1a0f0227564a9945fe36b90da5a93b3933fc3dc03fae372d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1440,27 +1435,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4f74086536d1e1deaff99ec0387481fb3325c82e4e48be0e75ab3d3fcb487a"
+checksum = "fdb6da8ec6fa5cedd1626c886fc8749bdcbb09424a86461eb8cdf096b7c33257"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e77dfeb76b32bbf069144a5ea0a36176ab59c8db9ce28732d0f06f096bbfbc8"
+checksum = "38a385202ff5a92791168b1136afae5059d3ac118457bb7bc304c197c2d33e7d"
 dependencies = [
  "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1474,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1533,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
@@ -1604,22 +1599,22 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.17"
+version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "log",
  "once_cell",
@@ -1632,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-webpki"
@@ -1658,22 +1653,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1757,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.89"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1774,7 +1769,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1816,12 +1811,13 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1838,11 +1834,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -1853,25 +1849,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1943,12 +1939,6 @@ checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
@@ -1973,9 +1963,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.10.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64",
  "flate2",
@@ -1989,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2049,9 +2039,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2060,24 +2050,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2085,22 +2074,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "web-time"
@@ -2257,9 +2246,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "xattr"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
 dependencies = [
  "libc",
  "linux-raw-sys",
@@ -2277,9 +2266,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -2289,13 +2278,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -2311,11 +2300,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.10"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13a42ed30c63171d820889b2981318736915150575b8d2d6dbee7edd68336ca"
+checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
 dependencies = [
- "zerocopy-derive 0.8.10",
+ "zerocopy-derive 0.8.14",
 ]
 
 [[package]]
@@ -2326,38 +2315,38 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.10"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "593e7c96176495043fcb9e87cf7659f4d18679b5bab6b92bdef359c76a7795dd"
+checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -2378,7 +2367,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2400,14 +2389,14 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "zip"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d52293fc86ea7cf13971b3bb81eb21683636e7ae24c729cdaf1b7c4157a352"
+checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
 dependencies = [
  "aes",
  "arbitrary",
@@ -2425,7 +2414,7 @@ dependencies = [
  "pbkdf2",
  "rand",
  "sha1",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "time",
  "zeroize",
  "zopfli",
@@ -2510,3 +2499,11 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "libwaj"
+version = "0.4.0-dev"
+
+[[patch.unused]]
+name = "waj"
+version = "0.4.0-dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 license-file = "LICENSE-MIT"
 
 [workspace.dependencies]
-jbk = { git = "https://github.com/jubako/jubako.git", package = "jubako", features = ["clap"], version = "0.3.3" }
+jbk = { git = "https://github.com/jubako/jubako.git", package = "jubako", features = ["clap"], version = "0.4.0-dev" }
 clap = { version = "4.4.5", features = ["derive", "cargo"] }
 clap_mangen = "0.2.20"
 clap_complete = "4.5.0"

--- a/arx/src/bin/auto_mount.rs
+++ b/arx/src/bin/auto_mount.rs
@@ -16,7 +16,7 @@ mod inner {
         pub mountdir: PathBuf,
     }
 
-    pub fn mount<INP, OUTP>(infile: INP, outdir: OUTP) -> jbk::Result<()>
+    pub fn mount<INP, OUTP>(infile: INP, outdir: OUTP) -> Result<(), arx::ArxError>
     where
         INP: AsRef<std::path::Path>,
         OUTP: AsRef<std::path::Path>,
@@ -49,17 +49,15 @@ fn main() -> ExitCode {
             }
             match mount(exe_path, args.mountdir) {
                 Ok(()) => ExitCode::SUCCESS,
-                Err(e) => match e.error {
-                    jbk::ErrorKind::NotAJbk => {
-                        eprintln!("Impossible to locate a Jubako archive in the executable.");
-                        eprintln!("This binary is not intented to be directly used, you must put a Jubako archive at its end.");
-                        ExitCode::FAILURE
-                    }
-                    _ => {
-                        eprintln!("Error: {e}");
-                        ExitCode::FAILURE
-                    }
-                },
+                Err(arx::ArxError::BaseError(arx::BaseError::Jbk(_))) => {
+                    eprintln!("Impossible to locate a Jubako archive in the executable.");
+                    eprintln!("This binary is not intented to be directly used, you must put a Jubako archive at its end.");
+                    ExitCode::FAILURE
+                }
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    ExitCode::FAILURE
+                }
             }
         }
         Err(e) => {

--- a/arx/src/bin/mount_fuse_arx.rs
+++ b/arx/src/bin/mount_fuse_arx.rs
@@ -50,6 +50,6 @@ fn main() -> Result<(), arx::MountError> {
 }
 
 #[cfg(windows)]
-fn main() -> jbk::Result<()> {
-    Err("Mount feature is not availble on Windows.".into())
+fn main() -> Result<(), &'static str> {
+    Err("Mount feature is not availble on Windows.")
 }

--- a/arx/src/bin/mount_fuse_arx.rs
+++ b/arx/src/bin/mount_fuse_arx.rs
@@ -15,7 +15,7 @@ mod inner {
         pub option: Vec<String>,
     }
 
-    pub fn mount<INP, OUTP>(infile: INP, outdir: OUTP) -> jbk::Result<()>
+    pub fn mount<INP, OUTP>(infile: INP, outdir: OUTP) -> Result<(), arx::ArxError>
     where
         INP: AsRef<std::path::Path>,
         OUTP: AsRef<std::path::Path>,
@@ -31,7 +31,7 @@ mod inner {
 }
 
 #[cfg(unix)]
-fn main() -> jbk::Result<()> {
+fn main() -> Result<(), arx::MountError> {
     use inner::*;
 
     human_panic::setup_panic!(human_panic::Metadata::new(
@@ -43,10 +43,10 @@ fn main() -> jbk::Result<()> {
 
     if args.option.contains(&"rw".into()) {
         eprintln!("arx cannot be mounted rw");
-        return Err("arx cannot be mounted rw".into());
+        return Err(arx::MountError::CannotMountRW);
     }
 
-    mount(args.infile, args.mountdir)
+    Ok(mount(args.infile, args.mountdir)?)
 }
 
 #[cfg(windows)]

--- a/arx/src/create.rs
+++ b/arx/src/create.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use clap::{Parser, ValueHint};
 
-const AFTER_HELP: &'static str = cstr!(
+const AFTER_HELP: &str = cstr!(
     "
 <s,u>Specifying input files:</>
 
@@ -69,7 +69,7 @@ It is not possible to force compression of content (patch welcome).
 "
 );
 
-const USAGE: &'static str = cstr!("<s>arx create</s> -o archive.arx [OPTIONS] [INFILES]...");
+const USAGE: &str = cstr!("<s>arx create</s> -o archive.arx [OPTIONS] [INFILES]...");
 
 /// Create an archive.
 #[derive(Parser, Debug)]

--- a/arx/src/extract.rs
+++ b/arx/src/extract.rs
@@ -75,7 +75,7 @@ pub struct Options {
     overwrite: arx::Overwrite,
 }
 
-fn get_files_to_extract(options: &Options) -> jbk::Result<HashSet<arx::PathBuf>> {
+fn get_files_to_extract(options: &Options) -> std::io::Result<HashSet<arx::PathBuf>> {
     if let Some(file_list) = &options.file_list {
         let file = File::open(file_list)?;
         let mut files: HashSet<arx::PathBuf> = Default::default();

--- a/arx/src/list.rs
+++ b/arx/src/list.rs
@@ -1,5 +1,5 @@
 use crate::light_path::LightPath;
-use arx::CommonEntry;
+use arx::{ArxError, CommonEntry};
 use jbk::reader::builder::PropertyBuilderTrait;
 use jbk::reader::ByteSlice;
 use log::info;
@@ -47,25 +47,34 @@ impl<W> arx::walk::Operator<LightPath, LightBuilder> for Lister<W>
 where
     W: std::io::Write,
 {
-    fn on_start(&self, _current_path: &mut LightPath) -> jbk::Result<()> {
+    type Error = ArxError;
+    fn on_start(&self, _current_path: &mut LightPath) -> Result<(), ArxError> {
         Ok(())
     }
-    fn on_stop(&self, _current_path: &mut LightPath) -> jbk::Result<()> {
+    fn on_stop(&self, _current_path: &mut LightPath) -> Result<(), ArxError> {
         Ok(())
     }
-    fn on_directory_enter(&self, current_path: &mut LightPath, path: &Path) -> jbk::Result<bool> {
+    fn on_directory_enter(
+        &self,
+        current_path: &mut LightPath,
+        path: &Path,
+    ) -> Result<bool, ArxError> {
         current_path.push(path.clone());
         current_path.println(self.output.borrow_mut().deref_mut())?;
         Ok(true)
     }
-    fn on_directory_exit(&self, current_path: &mut LightPath, _path: &Path) -> jbk::Result<()> {
+    fn on_directory_exit(
+        &self,
+        current_path: &mut LightPath,
+        _path: &Path,
+    ) -> Result<(), ArxError> {
         current_path.pop();
         Ok(())
     }
-    fn on_file(&self, current_path: &mut LightPath, path: &Path) -> jbk::Result<()> {
+    fn on_file(&self, current_path: &mut LightPath, path: &Path) -> Result<(), ArxError> {
         Ok(current_path.println2(path, self.output.borrow_mut().deref_mut())?)
     }
-    fn on_link(&self, current_path: &mut LightPath, path: &Path) -> jbk::Result<()> {
+    fn on_link(&self, current_path: &mut LightPath, path: &Path) -> Result<(), ArxError> {
         Ok(current_path.println2(path, self.output.borrow_mut().deref_mut())?)
     }
 }
@@ -81,17 +90,18 @@ impl<W> arx::walk::Operator<arx::PathBuf, arx::FullBuilder> for StableLister<W>
 where
     W: std::io::Write,
 {
-    fn on_start(&self, _current_path: &mut arx::PathBuf) -> jbk::Result<()> {
+    type Error = ArxError;
+    fn on_start(&self, _current_path: &mut arx::PathBuf) -> Result<(), ArxError> {
         Ok(())
     }
-    fn on_stop(&self, _current_path: &mut arx::PathBuf) -> jbk::Result<()> {
+    fn on_stop(&self, _current_path: &mut arx::PathBuf) -> Result<(), ArxError> {
         Ok(())
     }
     fn on_directory_enter(
         &self,
         current_path: &mut arx::PathBuf,
         dir: &arx::Dir,
-    ) -> jbk::Result<bool> {
+    ) -> Result<bool, ArxError> {
         current_path.push(String::from_utf8_lossy(dir.path()).as_ref());
         writeln!(
             self.output.borrow_mut(),
@@ -105,11 +115,15 @@ where
         &self,
         current_path: &mut arx::PathBuf,
         _dir: &arx::Dir,
-    ) -> jbk::Result<()> {
+    ) -> Result<(), ArxError> {
         current_path.pop();
         Ok(())
     }
-    fn on_file(&self, current_path: &mut arx::PathBuf, file: &arx::FileEntry) -> jbk::Result<()> {
+    fn on_file(
+        &self,
+        current_path: &mut arx::PathBuf,
+        file: &arx::FileEntry,
+    ) -> Result<(), ArxError> {
         current_path.push(String::from_utf8_lossy(file.path()).as_ref());
         writeln!(
             self.output.borrow_mut(),
@@ -121,7 +135,7 @@ where
         current_path.pop();
         Ok(())
     }
-    fn on_link(&self, current_path: &mut arx::PathBuf, link: &arx::Link) -> jbk::Result<()> {
+    fn on_link(&self, current_path: &mut arx::PathBuf, link: &arx::Link) -> Result<(), ArxError> {
         current_path.push(String::from_utf8_lossy(link.path()).as_ref());
         let target: PathBuf = String::from_utf8_lossy(link.target()).as_ref().into();
         writeln!(

--- a/arx/tests/extract_mount.rs
+++ b/arx/tests/extract_mount.rs
@@ -68,7 +68,7 @@ fn test_extract() -> Result {
 
     let extract_dir = tempfile::TempDir::new_in(env!("CARGO_TARGET_TMPDIR"))?;
     arx::extract(
-        &arx_file,
+        arx_file,
         extract_dir.path(),
         Default::default(),
         true,
@@ -100,7 +100,7 @@ fn test_extract_filter() -> Result {
 
     let extract_dir = tempfile::TempDir::with_prefix_in("extract_", env!("CARGO_TARGET_TMPDIR"))?;
     arx::extract(
-        &arx_file,
+        arx_file,
         extract_dir.path(),
         ["sub_dir_a".into()].into(),
         true,
@@ -378,7 +378,7 @@ fn test_extract_existing_content_error() -> Result {
     .check_fail(
         b"",
         &format_bytes!(
-            b"Error : Unknown error : File {} already exists.\n",
+            b"Error : File {} already exists.\n",
             join!(extract_dir / "sub_dir_a" / "existing_file")
                 .to_str()
                 .unwrap()

--- a/libarx/Cargo.toml
+++ b/libarx/Cargo.toml
@@ -25,6 +25,7 @@ epochs = "0.2.4"
 rayon = "1.10.0"
 bstr = "1.9.1"
 log = "0.4.22"
+thiserror = "1.0.64"
 
 [target.'cfg(not(windows))'.dependencies]
 fuser = { version = "0.15.0", optional = true }

--- a/libarx/src/arx.rs
+++ b/libarx/src/arx.rs
@@ -1,4 +1,5 @@
 use super::common::{AllProperties, Comparator, Entry, FullBuilderTrait, RealBuilder};
+use super::error::{ArxError, ArxFormatError, PathNotFound, QueryError};
 use jbk::reader::builder::BuilderTrait;
 use jbk::{reader::Range, EntryIdx};
 use std::path::Path;
@@ -19,19 +20,20 @@ impl std::ops::Deref for Arx {
 fn create_properties(
     container: &jbk::reader::Container,
     index: &jbk::reader::Index,
-) -> jbk::Result<AllProperties> {
-    AllProperties::new(
+) -> Result<AllProperties, ArxError> {
+    Ok(AllProperties::new(
         index.get_store(container.get_entry_storage())?,
         container.get_value_storage(),
-    )
+    )?)
 }
 
 impl Arx {
-    pub fn new<P: AsRef<Path>>(file: P) -> jbk::Result<Self> {
+    pub fn new<P: AsRef<Path>>(file: P) -> Result<Self, ArxError> {
         let container = jbk::reader::Container::new(&file)?;
         let root_index = container
             .get_directory_pack()
-            .get_index_from_name("arx_root")?;
+            .get_index_from_name("arx_root")?
+            .ok_or(ArxFormatError("No arx_root index"))?;
         let properties = create_properties(&container, &root_index)?;
         Ok(Self {
             container,
@@ -40,11 +42,11 @@ impl Arx {
         })
     }
 
-    pub fn create_properties(&self, index: &jbk::reader::Index) -> jbk::Result<AllProperties> {
+    pub fn create_properties(&self, index: &jbk::reader::Index) -> Result<AllProperties, ArxError> {
         create_properties(&self.container, index)
     }
 
-    pub fn get_entry<B>(&self, path: &crate::Path) -> jbk::Result<Entry<B::Entry>>
+    pub fn get_entry<B>(&self, path: &crate::Path) -> Result<Entry<B::Entry>, QueryError>
     where
         B: FullBuilderTrait,
     {
@@ -60,16 +62,18 @@ impl Arx {
             let comparator = comparator.compare_with(component.as_bytes());
             let found = current_range.find(&comparator)?;
             match found {
-                None => return Err("Cannot found entry".to_string().into()),
+                None => return Err(PathNotFound(path.into()).into()),
                 Some(idx) => {
-                    let entry = current_range.get_entry(&builder, idx)?;
+                    let entry = current_range
+                        .get_entry(&builder, idx)?
+                        .expect("idx is valid");
                     if components.peek().is_none() {
                         // We have the last component
                         return Ok(entry);
                     } else if let Entry::Dir(range, _) = entry {
                         current_range = range;
                     } else {
-                        return Err("Cannot found entry".to_string().into());
+                        return Err(PathNotFound(path.into()).into());
                     }
                 }
             }
@@ -77,11 +81,11 @@ impl Arx {
         unreachable!();
     }
 
-    pub fn get_entry_at_idx<B>(&self, idx: EntryIdx) -> jbk::Result<Entry<B::Entry>>
+    pub fn get_entry_at_idx<B>(&self, idx: EntryIdx) -> Result<Option<Entry<B::Entry>>, ArxError>
     where
         B: FullBuilderTrait,
     {
         let builder = RealBuilder::<B>::new(&self.properties);
-        builder.create_entry(idx)
+        Ok(builder.create_entry(idx)?)
     }
 }

--- a/libarx/src/common/entry_type.rs
+++ b/libarx/src/common/entry_type.rs
@@ -1,3 +1,7 @@
+use std::fmt::Display;
+
+use crate::ArxFormatError;
+
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[repr(u8)]
 pub enum EntryType {
@@ -7,23 +11,23 @@ pub enum EntryType {
 }
 
 impl TryFrom<jbk::VariantIdx> for EntryType {
-    type Error = String;
+    type Error = ArxFormatError;
     fn try_from(id: jbk::VariantIdx) -> Result<Self, Self::Error> {
         match id.into_u8() {
             0 => Ok(Self::File),
             1 => Ok(Self::Dir),
             2 => Ok(Self::Link),
-            _ => Err("Invalid variant id".into()),
+            _ => Err(ArxFormatError("Invalid variant id")),
         }
     }
 }
 
-impl ToString for EntryType {
-    fn to_string(&self) -> String {
+impl Display for EntryType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            EntryType::File => String::from("file"),
-            EntryType::Dir => String::from("dir"),
-            EntryType::Link => String::from("link"),
+            EntryType::File => write!(f, "file"),
+            EntryType::Dir => write!(f, "dir"),
+            EntryType::Link => write!(f, "link"),
         }
     }
 }

--- a/libarx/src/create/creator.rs
+++ b/libarx/src/create/creator.rs
@@ -18,7 +18,7 @@ impl SimpleCreator {
         progress: Arc<dyn jbk::creator::Progress>,
         cache_progress: Rc<dyn jbk::creator::CacheProgress>,
         compression: jbk::creator::Compression,
-    ) -> jbk::Result<Self> {
+    ) -> jbk::creator::Result<Self> {
         let basic_creator = BasicCreator::new(
             outfile,
             concat_mode,
@@ -38,9 +38,11 @@ impl SimpleCreator {
     }
 
     pub fn finalize(self, outfile: &Path) -> Void {
-        self.cached_content_creator
-            .into_inner()
-            .finalize(outfile, self.entry_store_creator, vec![])
+        Ok(self.cached_content_creator.into_inner().finalize(
+            outfile,
+            self.entry_store_creator,
+            vec![],
+        )?)
     }
 
     pub fn adder(&mut self) -> &mut impl ContentAdder {

--- a/libarx/src/create/mod.rs
+++ b/libarx/src/create/mod.rs
@@ -2,6 +2,7 @@ mod creator;
 mod entry_store_creator;
 mod fs_adder;
 
+use crate::CreatorError;
 pub use creator::SimpleCreator;
 pub use entry_store_creator::EntryStoreCreator;
 pub use fs_adder::FsAdder;
@@ -15,7 +16,7 @@ pub enum EntryKind {
 
 pub trait EntryTrait {
     /// The kind of the entry
-    fn kind(&self) -> jbk::Result<Option<EntryKind>>;
+    fn kind(&self) -> Result<Option<EntryKind>, CreatorError>;
 
     /// Under which name the entry will be stored
     fn path(&self) -> &crate::Path;
@@ -26,4 +27,4 @@ pub trait EntryTrait {
     fn mtime(&self) -> u64;
 }
 
-pub type Void = jbk::Result<()>;
+pub type Void = Result<(), CreatorError>;

--- a/libarx/src/error.rs
+++ b/libarx/src/error.rs
@@ -1,0 +1,166 @@
+use thiserror::Error;
+
+use crate::common::EntryType;
+
+#[derive(Error, Debug)]
+#[error("Path {0} not found in archive")]
+pub struct PathNotFound(pub crate::PathBuf);
+
+#[derive(Error, Debug)]
+#[error("Jbk archive is not a valid Arx archive : {0}")]
+pub struct ArxFormatError(pub &'static str);
+
+#[derive(Error, Debug)]
+#[error("Arx entry ({actual}) is not of the expected type ({expected}).")]
+pub struct WrongType {
+    pub expected: EntryType,
+    pub actual: EntryType,
+}
+
+#[derive(Error, Debug)]
+#[error("Incoherent structure : {0}")]
+pub struct IncoherentStructure(pub String);
+
+#[derive(Error, Debug)]
+#[error("Invalid input : {0}")]
+pub struct InputError(pub String);
+
+#[derive(Error, Debug)]
+pub enum BaseError {
+    #[error(transparent)]
+    Jbk(#[from] jbk::Error),
+    #[error(transparent)]
+    ArxFormatError(#[from] ArxFormatError),
+}
+
+#[derive(Error, Debug)]
+pub enum QueryError {
+    #[error(transparent)]
+    BaseError(#[from] BaseError),
+    #[error(transparent)]
+    PathNotFound(#[from] PathNotFound),
+}
+
+impl From<jbk::Error> for QueryError {
+    fn from(value: jbk::Error) -> Self {
+        Self::BaseError(value.into())
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ArxError {
+    #[error(transparent)]
+    BaseError(#[from] BaseError),
+
+    #[error("{0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error(transparent)]
+    PathNotFound(#[from] PathNotFound),
+
+    #[error("Not a directory")]
+    NotADirectory,
+    #[error("Is a directory")]
+    IsADirectory,
+    #[error("Is a link")]
+    IsALink,
+}
+
+impl From<jbk::Error> for ArxError {
+    fn from(value: jbk::Error) -> Self {
+        Self::BaseError(value.into())
+    }
+}
+
+impl From<ArxFormatError> for ArxError {
+    fn from(value: ArxFormatError) -> Self {
+        Self::BaseError(value.into())
+    }
+}
+
+impl From<QueryError> for ArxError {
+    fn from(value: QueryError) -> Self {
+        match value {
+            QueryError::BaseError(e) => Self::BaseError(e),
+            QueryError::PathNotFound(e) => Self::PathNotFound(e),
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum MountError {
+    #[error(transparent)]
+    ArxError(#[from] ArxError),
+
+    #[error("Cannot mount Read/Write")]
+    CannotMountRW,
+}
+
+#[derive(Error, Debug)]
+pub enum FsError {
+    #[error(transparent)]
+    BaseError(#[from] BaseError),
+
+    #[error(transparent)]
+    WrongType(#[from] WrongType),
+
+    #[error("Not found")]
+    NotFound,
+    #[error("Missing Pack")]
+    MissingPack,
+}
+
+impl From<jbk::Error> for FsError {
+    fn from(value: jbk::Error) -> Self {
+        Self::BaseError(value.into())
+    }
+}
+
+impl From<ArxFormatError> for FsError {
+    fn from(value: ArxFormatError) -> Self {
+        Self::BaseError(value.into())
+    }
+}
+
+// TODO: Move in arx crate
+#[derive(Error, Debug)]
+pub enum ExtractError {
+    #[error(transparent)]
+    ArxError(#[from] ArxError),
+
+    #[error("File {path} already exists.", path = path.display())]
+    FileExists { path: std::path::PathBuf },
+}
+
+impl From<jbk::Error> for ExtractError {
+    fn from(value: jbk::Error) -> Self {
+        Self::ArxError(value.into())
+    }
+}
+impl From<ArxFormatError> for ExtractError {
+    fn from(value: ArxFormatError) -> Self {
+        Self::ArxError(value.into())
+    }
+}
+impl From<BaseError> for ExtractError {
+    fn from(value: BaseError) -> Self {
+        Self::ArxError(value.into())
+    }
+}
+impl From<std::io::Error> for ExtractError {
+    fn from(value: std::io::Error) -> Self {
+        Self::ArxError(value.into())
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum CreatorError {
+    #[error(transparent)]
+    Jbk(#[from] jbk::creator::Error),
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    #[error(transparent)]
+    IncoherentStructure(#[from] IncoherentStructure),
+    #[error(transparent)]
+    InputError(#[from] InputError),
+}

--- a/libarx/src/lib.rs
+++ b/libarx/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cmd_utils;
 mod common;
 pub mod create;
 mod entry;
+mod error;
 mod tools;
 pub mod walk;
 
@@ -19,5 +20,6 @@ pub use common::{
     PathBuf, VENDOR_ID,
 };
 pub use entry::*;
+pub use error::*;
 pub use tools::{extract, extract_arx, extract_arx_range, Overwrite};
 pub use walk::*;

--- a/python/src/entry.rs
+++ b/python/src/entry.rs
@@ -73,6 +73,8 @@ impl Entry {
                 let arx_entry = self
                     .arx
                     .get_entry_at_idx::<arx::FullBuilder>(i)
+                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+                    .ok_or(arx::ArxFormatError("Invalid parent"))
                     .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
                 let entry = Entry::new(self.arx.clone(), arx_entry);
                 Ok(Some(entry))

--- a/python/src/iterator.rs
+++ b/python/src/iterator.rs
@@ -37,16 +37,15 @@ impl EntryIter {
         slf
     }
     fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<Entry>> {
-        if slf.start == slf.end {
+        if slf.start >= slf.end {
             return Ok(None);
         }
-        let ret = Entry::new(
-            Arc::clone(&slf.arx),
-            slf.arx
-                .get_entry_at_idx::<arx::FullBuilder>(slf.start)
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
-        );
+        let ret = slf
+            .arx
+            .get_entry_at_idx::<arx::FullBuilder>(slf.start)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+            .map(|e| Entry::new(Arc::clone(&slf.arx), e));
         slf.start += 1;
-        Ok(Some(ret))
+        Ok(ret)
     }
 }


### PR DESCRIPTION
Last version of Jubako refactor its error system and avoid us to store generic error in jbk's error. (and this is a good thing)

Now, arx functions return arx errors which may contain jbk error.

All error that can be considered as Arx format error (wrong property...) are now `ArxFormatError`, not jbk's `FormatError`