### PR TITLE
Adapt to new jbk api about variant and property name.

### DIFF
--- a/libarx/src/common/entry_type.rs
+++ b/libarx/src/common/entry_type.rs
@@ -1,24 +1,10 @@
 use std::fmt::Display;
 
-use crate::ArxFormatError;
-
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-#[repr(u8)]
-pub enum EntryType {
-    File = 0,
-    Dir = 1,
-    Link = 2,
-}
-
-impl TryFrom<jbk::VariantIdx> for EntryType {
-    type Error = ArxFormatError;
-    fn try_from(id: jbk::VariantIdx) -> Result<Self, Self::Error> {
-        match id.into_u8() {
-            0 => Ok(Self::File),
-            1 => Ok(Self::Dir),
-            2 => Ok(Self::Link),
-            _ => Err(ArxFormatError("Invalid variant id")),
-        }
+jbk::variants! {
+    EntryType {
+        File => "file",
+        Dir => "dir",
+        Link => "link"
     }
 }
 
@@ -31,8 +17,6 @@ impl Display for EntryType {
         }
     }
 }
-
-impl jbk::creator::VariantName for EntryType {}
 
 #[cfg(all(not(windows), feature = "fuse"))]
 impl From<EntryType> for fuser::FileType {

--- a/libarx/src/error.rs
+++ b/libarx/src/error.rs
@@ -1,6 +1,6 @@
-use thiserror::Error;
-
 use crate::common::EntryType;
+use std::fmt::Display;
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 #[error("Path {0} not found in archive")]
@@ -11,10 +11,27 @@ pub struct PathNotFound(pub crate::PathBuf);
 pub struct ArxFormatError(pub &'static str);
 
 #[derive(Error, Debug)]
-#[error("Arx entry ({actual}) is not of the expected type ({expected}).")]
 pub struct WrongType {
     pub expected: EntryType,
-    pub actual: EntryType,
+    pub actual: Option<EntryType>,
+}
+
+impl Display for WrongType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(e) = self.actual {
+            write!(
+                f,
+                "Arx entry ({}) is not of the expected type ({})",
+                e, self.expected
+            )
+        } else {
+            write!(
+                f,
+                "Arx entry has unknown type (Expected is {})",
+                self.expected
+            )
+        }
+    }
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
Jbk simplify a bit the definition of variant, properties and builder with the use of macro.

In the same time, it fixes an issue about wrong parsing of variant type (at least, not taking into account the variant name mapping).