### PR TITLE
Two steps entry store creation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arx"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -686,7 +686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "jubako"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "blake3",
  "camino",
@@ -1039,6 +1039,7 @@ dependencies = [
  "rayon",
  "smallvec",
  "spmc",
+ "static_assertions",
  "tempfile",
  "thiserror 2.0.17",
  "uuid",
@@ -1047,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "libarx"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bstr",
  "clap",
@@ -1488,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "python-libarx"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "jubako",
  "libarx",
@@ -1674,7 +1675,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1822,6 +1823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a8428da277a8e3a15271d79943e80ccc2ef254e78813a166a08d65e4c3ece5"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "tar2arx"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1891,7 +1898,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2204,7 +2211,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2513,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "zip2arx"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2576,12 +2583,4 @@ dependencies = [
 
 [[patch.unused]]
 name = "libwaj"
-version = "0.4.0-dev"
-
-[[patch.unused]]
-name = "waj"
-version = "0.4.0-dev"
-
-[[patch.unused]]
-name = "zim-sys"
-version = "0.1.0"
+version = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/jubako/arx"
 license = "MIT"
 
 [workspace.dependencies]
-jbk = { git = "https://github.com/jubako/jubako.git", package = "jubako", features = ["clap"], version = "0.4.0" }
+jbk = { git = "https://github.com/jubako/jubako.git", package = "jubako", features = ["clap"], version = "0.5.0-dev" }
 clap = { version = "4.4.5", features = ["derive", "cargo"] }
 clap_mangen = "0.2.20"
 clap_complete = "4.5.0"

--- a/libarx/src/create/entry_store_creator.rs
+++ b/libarx/src/create/entry_store_creator.rs
@@ -42,28 +42,29 @@ pub struct JbkEntry {
 }
 
 impl JbkEntry {
-    pub(crate) fn new(e: &Entry) -> Self {
-        Self {
+    pub(crate) fn new(e: Entry) -> (Self, Option<impl Iterator<Item = Entry>>) {
+        let mut next_children = None;
+        let s = Self {
             parent: e.parent,
-            name: e.name.clone(),
+            name: e.name,
             owner: e.owner,
             group: e.group,
             rights: e.rights,
             mtime: e.mtime,
-            kind: match &e.kind {
-                Kind::File { content, size } => JbkKind::File {
-                    content: *content,
-                    size: *size,
-                },
-                Kind::Link { target } => JbkKind::Link {
-                    target: target.clone(),
-                },
-                Kind::Dir(d_entry) => JbkKind::Dir {
-                    nb_children: d_entry.nb_children(),
-                    first_child: d_entry.first_child(),
-                },
+            kind: match e.kind {
+                Kind::File { content, size } => JbkKind::File { content, size },
+                Kind::Link { target } => JbkKind::Link { target },
+                Kind::Dir(d_entry) => {
+                    let d = JbkKind::Dir {
+                        nb_children: d_entry.nb_children(),
+                        first_child: d_entry.first_child(),
+                    };
+                    next_children = Some(d_entry.children.into_values());
+                    d
+                }
             },
-        }
+        };
+        (s, next_children)
     }
 }
 
@@ -219,7 +220,7 @@ impl jbk::creator::EntryStoreCreatorTrait for EntryStoreCreator {
         let root_count = self.root_entry.nb_children();
         directory_pack.add_value_store(self.path_store);
         let flatten = flat(self.root_entry);
-        let jbk_entry_store = EntryStore::new(self.schema, flatten.into_iter());
+        let jbk_entry_store = EntryStore::new(self.schema, flatten);
         let entry_store_id = directory_pack.add_entry_store(jbk_entry_store);
         directory_pack.create_index(
             "arx_entries",

--- a/libarx/src/create/entry_store_creator.rs
+++ b/libarx/src/create/entry_store_creator.rs
@@ -1,265 +1,59 @@
+use super::mut_entry_store::{flat, DirEntry, Entry, Kind};
 use crate::common::{EntryType, Property};
-use crate::IncoherentStructure;
 use jbk::creator::schema;
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
 
-use super::{EntryKind, EntryTrait, Void};
+use super::{EntryTrait, Void};
 
-type EntryStore = jbk::creator::EntryStore<
-    Property,
-    EntryType,
-    Box<jbk::creator::BasicEntry<Property, EntryType>>,
->;
+pub type JbkEntry = jbk::creator::BasicEntry<Property, EntryType>;
+pub type ArxSchema = schema::Schema<Property, EntryType>;
 
-type DirCache = HashMap<String, DirOrFile>;
-type EntryIdx = jbk::Bound<jbk::EntryIdx>;
+type EntryStore =
+    jbk::creator::EntryStore<Property, EntryType, jbk::creator::BasicEntry<Property, EntryType>>;
 
-enum DirOrFile {
-    Dir(DirEntry),
-    File(EntryIdx),
-}
+pub fn to_basic_entry(entry: &Entry, schema: &ArxSchema) -> JbkEntry {
+    let mut values = HashMap::from([
+        (
+            Property::Name,
+            jbk::Value::Array(entry.name.as_bytes().into()),
+        ),
+        (
+            Property::Parent,
+            jbk::Value::Unsigned(entry.parent.map_or(0, |p| p.into_u64() + 1)),
+        ),
+        (Property::Owner, jbk::Value::Unsigned(entry.owner)),
+        (Property::Group, jbk::Value::Unsigned(entry.group)),
+        (Property::Rights, jbk::Value::Unsigned(entry.rights)),
+        (Property::Mtime, jbk::Value::Unsigned(entry.mtime)),
+    ]);
 
-/// A DirEntry structure to keep track of added direcotry in the archive.
-/// This is needed as we may adde file without recursion, and so we need
-/// to find the parent of "foo/bar/baz.txt" ("foo/bar") when we add it.
-struct DirEntry {
-    idx: Option<EntryIdx>,
-    children: Arc<RwLock<DirCache>>,
-}
-
-impl DirEntry {
-    fn new_root() -> Self {
-        Self {
-            idx: None,
-            children: Default::default(),
+    let entry_type = match &entry.kind {
+        Kind::Dir(d) => {
+            values.insert(
+                Property::FirstChild,
+                jbk::Value::Unsigned(d.first_child().into_u64()),
+            );
+            values.insert(
+                Property::NbChildren,
+                jbk::Value::Unsigned(d.nb_children().into_u64()),
+            );
+            EntryType::Dir
         }
-    }
-    fn new(idx: EntryIdx) -> Self {
-        Self {
-            idx: Some(idx),
-            children: Default::default(),
+        Kind::File { content, size } => {
+            values.insert(Property::Content, jbk::Value::Content(*content));
+            values.insert(Property::Size, jbk::Value::Unsigned(*size));
+            EntryType::File
         }
-    }
-
-    fn first_entry_generator(&self) -> Box<dyn Fn() -> u64 + Sync + Send> {
-        let children = Arc::clone(&self.children);
-        Box::new(move || {
-            children
-                .try_read()
-                .unwrap()
-                .values()
-                .map(|e| match e {
-                    DirOrFile::File(i) => i.get().into_u64(),
-                    DirOrFile::Dir(e) => e.idx.as_ref().unwrap().get().into_u64(),
-                })
-                .min()
-                .unwrap_or(0)
-        })
-    }
-
-    fn entry_count_generator(&self) -> Box<dyn Fn() -> u64 + Sync + Send> {
-        let children = Arc::clone(&self.children);
-        Box::new(move || (children.try_read().unwrap().len()) as u64)
-    }
-
-    fn as_parent_idx_generator(&self) -> Box<dyn Fn() -> u64 + Sync + Send> {
-        match &self.idx {
-            Some(idx) => {
-                let idx = idx.clone();
-                Box::new(move || idx.get().into_u64() + 1)
-            }
-            None => Box::new(|| 0),
+        Kind::Link { target } => {
+            values.insert(Property::Target, jbk::Value::Array(target.to_vec().into()));
+            EntryType::Link
         }
-    }
-
-    fn add<'a, E, C>(&mut self, entry: &E, mut components: C, entry_store: &mut EntryStore) -> Void
-    where
-        E: EntryTrait + ?Sized,
-        C: Iterator<Item = relative_path::Component<'a>>,
-    {
-        match components.next() {
-            None => self.add_entry(entry, entry_store),
-            Some(component) => {
-                self.ensure_dir(component.as_str(), entry_store)?;
-                let mut write_children = self.children.try_write().unwrap();
-                match write_children.get_mut(component.as_str()).unwrap() {
-                    DirOrFile::Dir(e) => e.add(entry, components, entry_store),
-                    DirOrFile::File(_) => Err(IncoherentStructure(format!(
-                        "Adding {}, cannot add a entry to something which is not a directory",
-                        entry.path()
-                    ))
-                    .into()),
-                }
-            }
-        }
-    }
-
-    fn ensure_dir(&mut self, dir_name: &str, entry_store: &mut EntryStore) -> Void {
-        self.children
-            .try_write()
-            .unwrap()
-            .entry(dir_name.into())
-            .or_insert_with(|| {
-                let entry_idx = jbk::Vow::new(jbk::EntryIdx::from(0));
-                let dir_entry = DirEntry::new(entry_idx.bind());
-                let values = HashMap::from([
-                    (
-                        Property::Name,
-                        jbk::Value::Array(dir_name.as_bytes().into()),
-                    ),
-                    (
-                        Property::Parent,
-                        jbk::Value::UnsignedWord(self.as_parent_idx_generator().into()),
-                    ),
-                    (Property::Owner, jbk::Value::Unsigned(1000)),
-                    (Property::Group, jbk::Value::Unsigned(1000)),
-                    (Property::Rights, jbk::Value::Unsigned(0o755)),
-                    (Property::Mtime, jbk::Value::Unsigned(0)),
-                    (
-                        Property::FirstChild,
-                        jbk::Value::UnsignedWord(dir_entry.first_entry_generator().into()),
-                    ),
-                    (
-                        Property::NbChildren,
-                        jbk::Value::UnsignedWord(dir_entry.entry_count_generator().into()),
-                    ),
-                ]);
-
-                let entry = Box::new(jbk::creator::BasicEntry::new_from_schema_idx(
-                    &entry_store.schema,
-                    entry_idx,
-                    Some(EntryType::Dir),
-                    values,
-                ));
-                entry_store.add_entry(entry);
-                DirOrFile::Dir(dir_entry)
-            });
-
-        Ok(())
-    }
-
-    fn add_entry<E>(&mut self, entry: &E, entry_store: &mut EntryStore) -> Void
-    where
-        E: EntryTrait + ?Sized,
-    {
-        let entry_kind = match entry.kind()? {
-            Some(k) => k,
-            None => {
-                return Ok(());
-            }
-        };
-        let entry_name = entry
-            .path()
-            .file_name()
-            .unwrap_or_else(|| panic!("{:?} has no file name", entry.path()));
-        let mut values = HashMap::from([
-            (
-                Property::Name,
-                jbk::Value::Array(entry_name.as_bytes().into()),
-            ),
-            (
-                Property::Parent,
-                jbk::Value::UnsignedWord(self.as_parent_idx_generator().into()),
-            ),
-            (Property::Owner, jbk::Value::Unsigned(entry.uid())),
-            (Property::Group, jbk::Value::Unsigned(entry.gid())),
-            (Property::Rights, jbk::Value::Unsigned(entry.mode())),
-            (Property::Mtime, jbk::Value::Unsigned(entry.mtime())),
-        ]);
-
-        match entry_kind {
-            EntryKind::Dir => {
-                match self.children.try_read().unwrap().get(entry_name) {
-                    Some(DirOrFile::Dir(_)) => return Ok(()),
-                    Some(DirOrFile::File(_)) => {
-                        return Err(IncoherentStructure(format!(
-                            "Adding {}, cannot add a dir when file or link already exists",
-                            entry.path()
-                        ))
-                        .into())
-                    }
-                    None => {}
-                };
-                let entry_idx = jbk::Vow::new(jbk::EntryIdx::from(0));
-                let dir_entry = DirEntry::new(entry_idx.bind());
-
-                {
-                    values.insert(
-                        Property::FirstChild,
-                        jbk::Value::UnsignedWord(dir_entry.first_entry_generator().into()),
-                    );
-                    values.insert(
-                        Property::NbChildren,
-                        jbk::Value::UnsignedWord(dir_entry.entry_count_generator().into()),
-                    );
-                    let entry = Box::new(jbk::creator::BasicEntry::new_from_schema_idx(
-                        &entry_store.schema,
-                        entry_idx,
-                        Some(EntryType::Dir),
-                        values,
-                    ));
-                    entry_store.add_entry(entry);
-                }
-
-                self.children
-                    .try_write()
-                    .unwrap()
-                    .insert(entry_name.into(), DirOrFile::Dir(dir_entry));
-                Ok(())
-            }
-            EntryKind::File(size, content_address) => {
-                if self.children.try_read().unwrap().contains_key(entry_name) {
-                    return Err(IncoherentStructure(format!(
-                        "Adding {}, cannot add a file when one already exists",
-                        entry.path()
-                    ))
-                    .into());
-                }
-                values.insert(Property::Content, jbk::Value::Content(content_address));
-                values.insert(Property::Size, jbk::Value::Unsigned(size.into_u64()));
-                let entry = Box::new(jbk::creator::BasicEntry::new_from_schema(
-                    &entry_store.schema,
-                    Some(EntryType::File),
-                    values,
-                ));
-                let current_idx = entry_store.add_entry(entry);
-                self.children
-                    .try_write()
-                    .unwrap()
-                    .insert(entry_name.into(), DirOrFile::File(current_idx));
-                Ok(())
-            }
-            EntryKind::Link(target) => {
-                if self.children.try_read().unwrap().contains_key(entry_name) {
-                    return Err(IncoherentStructure(format!(
-                        "Adding {}, cannot add a link when one already exists",
-                        entry.path()
-                    ))
-                    .into());
-                }
-                values.insert(
-                    Property::Target,
-                    jbk::Value::Array(Vec::from(target).into()),
-                );
-                let entry = Box::new(jbk::creator::BasicEntry::new_from_schema(
-                    &entry_store.schema,
-                    Some(EntryType::Link),
-                    values,
-                ));
-                let current_idx = entry_store.add_entry(entry);
-                self.children
-                    .try_write()
-                    .unwrap()
-                    .insert(entry_name.into(), DirOrFile::File(current_idx));
-                Ok(())
-            }
-        }
-    }
+    };
+    jbk::creator::BasicEntry::new_from_schema(schema, Some(entry_type), values)
 }
 
 pub struct EntryStoreCreator {
-    entry_store: Box<EntryStore>,
+    schema: schema::Schema<Property, EntryType>,
     path_store: jbk::creator::StoreHandle,
     root_entry: DirEntry,
 }
@@ -268,7 +62,7 @@ impl EntryStoreCreator {
     pub fn new() -> Self {
         let path_store = jbk::creator::ValueStore::new_plain(None);
 
-        let entry_def = schema::Schema::new(
+        let schema = schema::Schema::new(
             // Common part
             schema::CommonProperties::new(vec![
                 schema::Property::new_array(1, path_store.clone(), Property::Name), // the path
@@ -305,20 +99,12 @@ impl EntryStoreCreator {
             ],
             Some(vec![Property::Parent, Property::Name]),
         );
-
-        let entry_store = Box::new(EntryStore::new(entry_def, None));
-
-        let root_entry = DirEntry::new_root();
-
+        let root_entry = DirEntry::new();
         Self {
-            entry_store,
+            schema,
             path_store,
             root_entry,
         }
-    }
-
-    pub fn entry_count(&self) -> jbk::EntryCount {
-        jbk::EntryCount::from(self.root_entry.entry_count_generator()() as u32)
     }
 
     pub fn add_entry<E>(&mut self, entry: &E) -> Void
@@ -327,28 +113,29 @@ impl EntryStoreCreator {
     {
         let path = entry.path();
         match path.parent() {
-            None => self
-                .root_entry
-                .add(entry, std::iter::empty(), &mut self.entry_store),
-            Some(parent) => self
-                .root_entry
-                .add(entry, parent.components(), &mut self.entry_store),
+            None => self.root_entry.add(entry, std::iter::empty()),
+            Some(parent) => self.root_entry.add(entry, parent.components()),
         }
     }
 }
 
 impl jbk::creator::EntryStoreTrait for EntryStoreCreator {
     fn finalize(self: Box<Self>, directory_pack: &mut jbk::creator::DirectoryPackCreator) {
-        let root_count = self.entry_count();
-        let entry_count = self.entry_store.len();
+        let entry_count = self.root_entry.nb_entry();
+        let root_count = self.root_entry.nb_children();
         directory_pack.add_value_store(self.path_store);
-        let entry_store_id = directory_pack.add_entry_store(self.entry_store);
+        let flatten = flat(self.root_entry, &self.schema);
+        let mut jbk_entry_store = EntryStore::new(self.schema, Some(flatten.len()));
+        for entry in flatten {
+            jbk_entry_store.add_entry(entry);
+        }
+        let entry_store_id = directory_pack.add_entry_store(Box::new(jbk_entry_store));
         directory_pack.create_index(
             "arx_entries",
             Default::default(),
             jbk::PropertyIdx::from(0),
             entry_store_id,
-            jbk::EntryCount::from(entry_count as u32),
+            entry_count,
             jbk::EntryIdx::from(0).into(),
         );
         directory_pack.create_index(

--- a/libarx/src/create/entry_store_creator.rs
+++ b/libarx/src/create/entry_store_creator.rs
@@ -1,60 +1,155 @@
 use super::mut_entry_store::{flat, DirEntry, Entry, Kind};
 use crate::common::{EntryType, Property};
 use jbk::creator::schema;
-use std::collections::HashMap;
+use jbk::Value;
 
 use super::{EntryTrait, Void};
 
-pub type JbkEntry = jbk::creator::SimpleEntry<Property, EntryType>;
 pub type ArxSchema = schema::Schema<Property, EntryType>;
 
 type EntryStore = jbk::creator::EntryStore<Property, EntryType>;
-
-pub fn to_basic_entry(entry: &Entry) -> JbkEntry {
-    let mut values = HashMap::from([
-        (
-            Property::Name,
-            jbk::Value::Array(entry.name.as_bytes().into()),
-        ),
-        (
-            Property::Parent,
-            jbk::Value::Unsigned(entry.parent.map_or(0, |p| p.into_u64() + 1)),
-        ),
-        (Property::Owner, jbk::Value::Unsigned(entry.owner)),
-        (Property::Group, jbk::Value::Unsigned(entry.group)),
-        (Property::Rights, jbk::Value::Unsigned(entry.rights)),
-        (Property::Mtime, jbk::Value::Unsigned(entry.mtime)),
-    ]);
-
-    let entry_type = match &entry.kind {
-        Kind::Dir(d) => {
-            values.insert(
-                Property::FirstChild,
-                jbk::Value::Unsigned(d.first_child().into_u64()),
-            );
-            values.insert(
-                Property::NbChildren,
-                jbk::Value::Unsigned(d.nb_children().into_u64()),
-            );
-            EntryType::Dir
-        }
-        Kind::File { content, size } => {
-            values.insert(Property::Content, jbk::Value::Content(*content));
-            values.insert(Property::Size, jbk::Value::Unsigned(*size));
-            EntryType::File
-        }
-        Kind::Link { target } => {
-            values.insert(Property::Target, jbk::Value::Array(target.to_vec().into()));
-            EntryType::Link
-        }
-    };
-    jbk::creator::SimpleEntry::new(entry_type, values)
-}
 
 pub struct EntryStoreCreator {
     schema: ArxSchema,
     path_store: jbk::creator::StoreHandle,
     root_entry: DirEntry,
+}
+
+#[derive(Debug)]
+pub enum JbkKind {
+    Dir {
+        first_child: jbk::EntryIdx,
+        nb_children: jbk::EntryCount,
+    },
+    File {
+        content: jbk::ContentAddress,
+        size: u64,
+    },
+    Link {
+        target: bstr::BString,
+    },
+}
+
+#[derive(Debug)]
+pub struct JbkEntry {
+    pub parent: Option<jbk::EntryIdx>,
+    pub name: String,
+    pub owner: u64,
+    pub group: u64,
+    pub rights: u64,
+    pub mtime: u64,
+    pub kind: JbkKind,
+}
+
+impl JbkEntry {
+    pub(crate) fn new(e: &Entry) -> Self {
+        Self {
+            parent: e.parent,
+            name: e.name.clone(),
+            owner: e.owner,
+            group: e.group,
+            rights: e.rights,
+            mtime: e.mtime,
+            kind: match &e.kind {
+                Kind::File { content, size } => JbkKind::File {
+                    content: *content,
+                    size: *size,
+                },
+                Kind::Link { target } => JbkKind::Link {
+                    target: target.clone(),
+                },
+                Kind::Dir(d_entry) => JbkKind::Dir {
+                    nb_children: d_entry.nb_children(),
+                    first_child: d_entry.first_child(),
+                },
+            },
+        }
+    }
+}
+
+impl jbk::creator::EntryTrait<Property, EntryType> for JbkEntry {
+    fn variant_name(&self) -> Option<EntryType> {
+        Some(match self.kind {
+            JbkKind::File {
+                content: _,
+                size: _,
+            } => EntryType::File,
+            JbkKind::Link { target: _ } => EntryType::Link,
+            JbkKind::Dir {
+                nb_children: _,
+                first_child: _,
+            } => EntryType::Dir,
+        })
+    }
+
+    fn value(&self, name: &Property) -> Value {
+        match name {
+            Property::Name => Value::Array(self.name.as_bytes().into()),
+            Property::Parent => Value::Unsigned(self.parent.map_or(0, |p| p.into_u64() + 1)),
+            Property::Owner => Value::Unsigned(self.owner),
+            Property::Group => Value::Unsigned(self.group),
+            Property::Rights => Value::Unsigned(self.rights),
+            Property::Mtime => Value::Unsigned(self.mtime),
+            Property::Content => {
+                if let JbkKind::File { content, size: _ } = self.kind {
+                    Value::Content(content)
+                } else {
+                    panic!("Should be a file")
+                }
+            }
+            Property::Size => {
+                if let JbkKind::File { content: _, size } = self.kind {
+                    Value::Unsigned(size)
+                } else {
+                    panic!("Should be a file")
+                }
+            }
+            Property::Target => {
+                if let JbkKind::Link { target } = &self.kind {
+                    Value::Array(target.to_vec().into())
+                } else {
+                    panic!("Should be a link")
+                }
+            }
+            Property::FirstChild => {
+                if let JbkKind::Dir {
+                    first_child,
+                    nb_children: _,
+                } = self.kind
+                {
+                    Value::Unsigned(first_child.into_u64())
+                } else {
+                    panic!("Should be a dir")
+                }
+            }
+            Property::NbChildren => {
+                if let JbkKind::Dir {
+                    first_child: _,
+                    nb_children,
+                } = self.kind
+                {
+                    Value::Unsigned(nb_children.into_u64())
+                } else {
+                    panic!("Should be a dir")
+                }
+            }
+        }
+    }
+
+    fn value_count(&self) -> jbk::PropertyCount {
+        match self.kind {
+            JbkKind::Dir {
+                first_child: _,
+                nb_children: _,
+            } => 6 + 2,
+            JbkKind::File {
+                content: _,
+                size: _,
+            } => 6 + 2,
+            JbkKind::Link { target: _ } => 6 + 1,
+        }
+        .into()
+    }
 }
 
 impl EntryStoreCreator {

--- a/libarx/src/create/entry_store_creator.rs
+++ b/libarx/src/create/entry_store_creator.rs
@@ -136,7 +136,7 @@ impl jbk::creator::EntryStoreTrait for EntryStoreCreator {
             jbk::PropertyIdx::from(0),
             entry_store_id,
             entry_count,
-            jbk::EntryIdx::from(0).into(),
+            jbk::EntryIdx::from(0),
         );
         directory_pack.create_index(
             "arx_root",
@@ -144,7 +144,7 @@ impl jbk::creator::EntryStoreTrait for EntryStoreCreator {
             jbk::PropertyIdx::from(0),
             entry_store_id,
             root_count,
-            jbk::EntryIdx::from(0).into(),
+            jbk::EntryIdx::from(0),
         );
     }
 }

--- a/libarx/src/create/entry_store_creator.rs
+++ b/libarx/src/create/entry_store_creator.rs
@@ -5,13 +5,12 @@ use std::collections::HashMap;
 
 use super::{EntryTrait, Void};
 
-pub type JbkEntry = jbk::creator::BasicEntry<Property, EntryType>;
+pub type JbkEntry = jbk::creator::SimpleEntry<Property, EntryType>;
 pub type ArxSchema = schema::Schema<Property, EntryType>;
 
-type EntryStore =
-    jbk::creator::EntryStore<Property, EntryType, jbk::creator::BasicEntry<Property, EntryType>>;
+type EntryStore = jbk::creator::EntryStore<Property, EntryType>;
 
-pub fn to_basic_entry(entry: &Entry, schema: &ArxSchema) -> JbkEntry {
+pub fn to_basic_entry(entry: &Entry) -> JbkEntry {
     let mut values = HashMap::from([
         (
             Property::Name,
@@ -49,11 +48,11 @@ pub fn to_basic_entry(entry: &Entry, schema: &ArxSchema) -> JbkEntry {
             EntryType::Link
         }
     };
-    jbk::creator::BasicEntry::new_from_schema(schema, Some(entry_type), values)
+    jbk::creator::SimpleEntry::new(entry_type, values)
 }
 
 pub struct EntryStoreCreator {
-    schema: schema::Schema<Property, EntryType>,
+    schema: ArxSchema,
     path_store: jbk::creator::StoreHandle,
     root_entry: DirEntry,
 }
@@ -119,17 +118,14 @@ impl EntryStoreCreator {
     }
 }
 
-impl jbk::creator::EntryStoreTrait for EntryStoreCreator {
+impl jbk::creator::EntryStoreCreatorTrait for EntryStoreCreator {
     fn finalize(self: Box<Self>, directory_pack: &mut jbk::creator::DirectoryPackCreator) {
         let entry_count = self.root_entry.nb_entry();
         let root_count = self.root_entry.nb_children();
         directory_pack.add_value_store(self.path_store);
-        let flatten = flat(self.root_entry, &self.schema);
-        let mut jbk_entry_store = EntryStore::new(self.schema, Some(flatten.len()));
-        for entry in flatten {
-            jbk_entry_store.add_entry(entry);
-        }
-        let entry_store_id = directory_pack.add_entry_store(Box::new(jbk_entry_store));
+        let flatten = flat(self.root_entry);
+        let jbk_entry_store = EntryStore::new(self.schema, flatten.into_iter());
+        let entry_store_id = directory_pack.add_entry_store(jbk_entry_store);
         directory_pack.create_index(
             "arx_entries",
             Default::default(),
@@ -159,7 +155,7 @@ impl Default for EntryStoreCreator {
 mod tests {
     use super::super::*;
     use super::*;
-    use jbk::creator::EntryStoreTrait;
+    use jbk::creator::EntryStoreCreatorTrait;
     use rustest::{test, *};
 
     #[test]

--- a/libarx/src/create/mod.rs
+++ b/libarx/src/create/mod.rs
@@ -1,6 +1,7 @@
 mod creator;
 mod entry_store_creator;
 mod fs_adder;
+mod mut_entry_store;
 
 use crate::CreatorError;
 pub use creator::SimpleCreator;

--- a/libarx/src/create/mut_entry_store.rs
+++ b/libarx/src/create/mut_entry_store.rs
@@ -1,0 +1,302 @@
+use super::entry_store_creator::{to_basic_entry, ArxSchema, JbkEntry};
+use crate::IncoherentStructure;
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+
+use super::{EntryKind, EntryTrait, Void};
+
+pub enum Kind {
+    Dir(DirEntry),
+    File {
+        content: jbk::ContentAddress,
+        size: u64,
+    },
+    Link {
+        target: bstr::BString,
+    },
+}
+
+pub struct Entry {
+    pub idx: Option<jbk::EntryIdx>,
+    pub parent: Option<jbk::EntryIdx>,
+    pub name: String,
+    pub owner: u64,
+    pub group: u64,
+    pub rights: u64,
+    pub mtime: u64,
+    pub kind: Kind,
+}
+
+impl Entry {
+    fn new_dir(name: String, owner: u64, group: u64, rights: u64, mtime: u64) -> Self {
+        Self {
+            idx: None,
+            parent: None,
+            name,
+            owner,
+            group,
+            rights,
+            mtime,
+            kind: Kind::Dir(DirEntry::new()),
+        }
+    }
+    fn new_file(
+        name: String,
+        owner: u64,
+        group: u64,
+        rights: u64,
+        mtime: u64,
+        content: jbk::ContentAddress,
+        size: u64,
+    ) -> Self {
+        Self {
+            idx: None,
+            parent: None,
+            name,
+            owner,
+            group,
+            rights,
+            mtime,
+            kind: Kind::File { content, size },
+        }
+    }
+    fn new_link(
+        name: String,
+        owner: u64,
+        group: u64,
+        rights: u64,
+        mtime: u64,
+        target: bstr::BString,
+    ) -> Self {
+        Self {
+            idx: None,
+            parent: None,
+            name,
+            owner,
+            group,
+            rights,
+            mtime,
+            kind: Kind::Link { target },
+        }
+    }
+
+    fn nb_children(&self) -> jbk::EntryCount {
+        match &self.kind {
+            Kind::Dir(dir) => dir.nb_entry(),
+            _ => 0.into(),
+        }
+    }
+
+    fn set_idx(&mut self, idx: jbk::EntryIdx, parent: Option<jbk::EntryIdx>) {
+        self.idx = Some(idx);
+        self.parent = parent;
+    }
+}
+
+type DirCache = BTreeMap<String, Entry>;
+
+/// A DirEntry structure to keep track of added direcotry in the archive.
+/// This is needed as we may adde file without recursion, and so we need
+/// to find the parent of "foo/bar/baz.txt" ("foo/bar") when we add it.
+pub struct DirEntry {
+    children: Arc<RwLock<DirCache>>,
+}
+
+impl DirEntry {
+    pub fn new() -> Self {
+        Self {
+            children: Default::default(),
+        }
+    }
+
+    pub fn first_child(&self) -> jbk::EntryIdx {
+        self.children
+            .read()
+            .unwrap()
+            .first_key_value()
+            .map_or(jbk::EntryIdx::from(0), |(_, v)| v.idx.unwrap())
+    }
+
+    pub fn nb_children(&self) -> jbk::EntryCount {
+        jbk::EntryCount::from(self.children.read().unwrap().len() as u32)
+    }
+
+    pub fn nb_entry(&self) -> jbk::EntryCount {
+        let mut nb_entry = self.nb_children();
+        for child in self.children.read().unwrap().values() {
+            nb_entry += child.nb_children().into_u32();
+        }
+        nb_entry
+    }
+
+    pub fn add<'a, E, C>(&mut self, entry: &E, mut components: C) -> Void
+    where
+        E: EntryTrait + ?Sized,
+        C: Iterator<Item = relative_path::Component<'a>>,
+    {
+        match components.next() {
+            None => self.add_entry(entry),
+            Some(component) => {
+                self.ensure_dir(component.as_str())?;
+                let mut write_children = self.children.try_write().unwrap();
+                match &mut write_children.get_mut(component.as_str()).unwrap().kind {
+                    Kind::Dir(e) => e.add(entry, components),
+                    Kind::File{content: _, size:_} => Err(IncoherentStructure(format!(
+                        "Adding {}, cannot add a entry to something which is not a directory (file)",
+                        entry.path()
+                    ))
+                    .into()),
+                    Kind::Link{target:_} => Err(IncoherentStructure(format!(
+                        "Adding {}, cannot add a entry to something which is not a directory (link)",
+                        entry.path()
+                    ))
+                    .into()),
+                }
+            }
+        }
+    }
+
+    fn ensure_dir(&mut self, dir_name: &str) -> Void {
+        self.children
+            .try_write()
+            .unwrap()
+            .entry(dir_name.into())
+            .or_insert_with(|| Entry::new_dir(dir_name.into(), 1000, 1000, 0o755, 0));
+
+        Ok(())
+    }
+
+    fn add_entry<E>(&mut self, entry: &E) -> Void
+    where
+        E: EntryTrait + ?Sized,
+    {
+        let entry_kind = match entry.kind()? {
+            Some(k) => k,
+            None => {
+                return Ok(());
+            }
+        };
+        let entry_name = entry
+            .path()
+            .file_name()
+            .unwrap_or_else(|| panic!("{:?} has no file name", entry.path()));
+
+        match entry_kind {
+            EntryKind::Dir => {
+                if let Some(existing_entry) = self.children.try_read().unwrap().get(entry_name) {
+                    match existing_entry.kind {
+                        Kind::Dir(_) => return Ok(()),
+                        Kind::File {
+                            content: _,
+                            size: _,
+                        } => {
+                            return Err(IncoherentStructure(format!(
+                                "Adding {}, cannot add a dir when file already exists",
+                                entry.path()
+                            ))
+                            .into())
+                        }
+                        Kind::Link { target: _ } => {
+                            return Err(IncoherentStructure(format!(
+                                "Adding {}, cannot add a dir when link already exists",
+                                entry.path()
+                            ))
+                            .into())
+                        }
+                    }
+                };
+
+                self.children.try_write().unwrap().insert(
+                    entry_name.into(),
+                    Entry::new_dir(
+                        entry_name.into(),
+                        entry.uid(),
+                        entry.gid(),
+                        entry.mode(),
+                        entry.mtime(),
+                    ),
+                );
+                Ok(())
+            }
+            EntryKind::File(size, content_address) => {
+                if self.children.try_read().unwrap().contains_key(entry_name) {
+                    return Err(IncoherentStructure(format!(
+                        "Adding {}, cannot add a file when one already exists",
+                        entry.path()
+                    ))
+                    .into());
+                }
+                self.children.try_write().unwrap().insert(
+                    entry_name.into(),
+                    Entry::new_file(
+                        entry_name.into(),
+                        entry.uid(),
+                        entry.gid(),
+                        entry.mode(),
+                        entry.mtime(),
+                        content_address,
+                        size.into_u64(),
+                    ),
+                );
+                Ok(())
+            }
+            EntryKind::Link(target) => {
+                if self.children.try_read().unwrap().contains_key(entry_name) {
+                    return Err(IncoherentStructure(format!(
+                        "Adding {}, cannot add a link when one already exists",
+                        entry.path()
+                    ))
+                    .into());
+                }
+                self.children.try_write().unwrap().insert(
+                    entry_name.into(),
+                    Entry::new_link(
+                        entry_name.into(),
+                        entry.uid(),
+                        entry.gid(),
+                        entry.mode(),
+                        entry.mtime(),
+                        target,
+                    ),
+                );
+                Ok(())
+            }
+        }
+    }
+}
+
+fn set_idx(
+    parent_dir: &mut DirEntry,
+    idx: &mut impl Iterator<Item = u32>,
+    parent_idx: Option<jbk::EntryIdx>,
+) {
+    for child in parent_dir.children.try_write().unwrap().values_mut() {
+        child.set_idx(jbk::EntryIdx::from(idx.next().unwrap()), parent_idx);
+    }
+    for child in parent_dir.children.try_write().unwrap().values_mut() {
+        if let Kind::Dir(d) = &mut child.kind {
+            set_idx(d, idx, child.idx);
+        }
+    }
+}
+
+fn flatten(entry: &mut DirEntry, res: &mut Vec<JbkEntry>, schema: &ArxSchema) {
+    for child in entry.children.try_write().unwrap().values_mut() {
+        res.push(to_basic_entry(child, schema));
+    }
+    for child in entry.children.try_write().unwrap().values_mut() {
+        if let Kind::Dir(d) = &mut child.kind {
+            flatten(d, res, schema);
+        }
+    }
+}
+
+pub fn flat(mut tree: DirEntry, schema: &ArxSchema) -> Vec<JbkEntry> {
+    let mut idx = std::ops::RangeFrom { start: 0 };
+
+    set_idx(&mut tree, &mut idx, None);
+
+    let mut res = Vec::with_capacity(idx.next().unwrap() as usize);
+    flatten(&mut tree, &mut res, schema);
+    res
+}

--- a/libarx/src/create/mut_entry_store.rs
+++ b/libarx/src/create/mut_entry_store.rs
@@ -1,6 +1,6 @@
 use super::entry_store_creator::{to_basic_entry, ArxSchema, JbkEntry};
 use crate::IncoherentStructure;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 
 use super::{EntryKind, EntryTrait, Void};
 
@@ -260,28 +260,39 @@ impl DirEntry {
     }
 }
 
-fn set_idx(
-    parent_dir: &mut DirEntry,
-    idx: &mut impl Iterator<Item = u32>,
-    parent_idx: Option<jbk::EntryIdx>,
-) {
+fn set_idx(parent_dir: &mut DirEntry, idx: &mut impl Iterator<Item = u32>) {
+    let mut to_visit = VecDeque::new();
+
     for child in parent_dir.children.values_mut() {
-        child.set_idx(jbk::EntryIdx::from(idx.next().unwrap()), parent_idx);
+        to_visit.push_back((None, child));
     }
-    for child in parent_dir.children.values_mut() {
-        if let Kind::Dir(d) = &mut child.kind {
-            set_idx(d, idx, child.idx);
+
+    let mut next_idx = || idx.next().map(jbk::EntryIdx::from);
+
+    while let Some((parent_idx, entry)) = to_visit.pop_front() {
+        let idx = next_idx();
+        entry.set_idx(idx.unwrap(), parent_idx);
+        if let Kind::Dir(d) = &mut entry.kind {
+            for child in d.children.values_mut() {
+                to_visit.push_back((idx, child));
+            }
         }
     }
 }
 
 fn flatten(entry: &mut DirEntry, res: &mut Vec<JbkEntry>, schema: &ArxSchema) {
+    let mut to_visit = VecDeque::new();
+
     for child in entry.children.values_mut() {
-        res.push(to_basic_entry(child, schema));
+        to_visit.push_back(child);
     }
-    for child in entry.children.values_mut() {
-        if let Kind::Dir(d) = &mut child.kind {
-            flatten(d, res, schema);
+
+    while let Some(entry) = to_visit.pop_front() {
+        res.push(to_basic_entry(entry, schema));
+        if let Kind::Dir(d) = &mut entry.kind {
+            for child in d.children.values_mut() {
+                to_visit.push_back(child);
+            }
         }
     }
 }
@@ -289,7 +300,7 @@ fn flatten(entry: &mut DirEntry, res: &mut Vec<JbkEntry>, schema: &ArxSchema) {
 pub fn flat(mut tree: DirEntry, schema: &ArxSchema) -> Vec<JbkEntry> {
     let mut idx = std::ops::RangeFrom { start: 0 };
 
-    set_idx(&mut tree, &mut idx, None);
+    set_idx(&mut tree, &mut idx);
 
     let mut res = Vec::with_capacity(idx.next().unwrap() as usize);
     flatten(&mut tree, &mut res, schema);

--- a/libarx/src/create/mut_entry_store.rs
+++ b/libarx/src/create/mut_entry_store.rs
@@ -1,7 +1,6 @@
 use super::entry_store_creator::{to_basic_entry, ArxSchema, JbkEntry};
 use crate::IncoherentStructure;
 use std::collections::BTreeMap;
-use std::sync::{Arc, RwLock};
 
 use super::{EntryKind, EntryTrait, Void};
 
@@ -99,7 +98,7 @@ type DirCache = BTreeMap<String, Entry>;
 /// This is needed as we may adde file without recursion, and so we need
 /// to find the parent of "foo/bar/baz.txt" ("foo/bar") when we add it.
 pub struct DirEntry {
-    children: Arc<RwLock<DirCache>>,
+    children: DirCache,
 }
 
 impl DirEntry {
@@ -111,19 +110,17 @@ impl DirEntry {
 
     pub fn first_child(&self) -> jbk::EntryIdx {
         self.children
-            .read()
-            .unwrap()
             .first_key_value()
             .map_or(jbk::EntryIdx::from(0), |(_, v)| v.idx.unwrap())
     }
 
     pub fn nb_children(&self) -> jbk::EntryCount {
-        jbk::EntryCount::from(self.children.read().unwrap().len() as u32)
+        jbk::EntryCount::from(self.children.len() as u32)
     }
 
     pub fn nb_entry(&self) -> jbk::EntryCount {
         let mut nb_entry = self.nb_children();
-        for child in self.children.read().unwrap().values() {
+        for child in self.children.values() {
             nb_entry += child.nb_children().into_u32();
         }
         nb_entry
@@ -138,7 +135,7 @@ impl DirEntry {
             None => self.add_entry(entry),
             Some(component) => {
                 self.ensure_dir(component.as_str())?;
-                let mut write_children = self.children.try_write().unwrap();
+                let write_children = &mut self.children;
                 match &mut write_children.get_mut(component.as_str()).unwrap().kind {
                     Kind::Dir(e) => e.add(entry, components),
                     Kind::File{content: _, size:_} => Err(IncoherentStructure(format!(
@@ -158,8 +155,6 @@ impl DirEntry {
 
     fn ensure_dir(&mut self, dir_name: &str) -> Void {
         self.children
-            .try_write()
-            .unwrap()
             .entry(dir_name.into())
             .or_insert_with(|| Entry::new_dir(dir_name.into(), 1000, 1000, 0o755, 0));
 
@@ -183,7 +178,7 @@ impl DirEntry {
 
         match entry_kind {
             EntryKind::Dir => {
-                if let Some(existing_entry) = self.children.try_read().unwrap().get(entry_name) {
+                if let Some(existing_entry) = self.children.get(entry_name) {
                     match existing_entry.kind {
                         Kind::Dir(_) => return Ok(()),
                         Kind::File {
@@ -206,7 +201,7 @@ impl DirEntry {
                     }
                 };
 
-                self.children.try_write().unwrap().insert(
+                self.children.insert(
                     entry_name.into(),
                     Entry::new_dir(
                         entry_name.into(),
@@ -219,14 +214,14 @@ impl DirEntry {
                 Ok(())
             }
             EntryKind::File(size, content_address) => {
-                if self.children.try_read().unwrap().contains_key(entry_name) {
+                if self.children.contains_key(entry_name) {
                     return Err(IncoherentStructure(format!(
                         "Adding {}, cannot add a file when one already exists",
                         entry.path()
                     ))
                     .into());
                 }
-                self.children.try_write().unwrap().insert(
+                self.children.insert(
                     entry_name.into(),
                     Entry::new_file(
                         entry_name.into(),
@@ -241,14 +236,14 @@ impl DirEntry {
                 Ok(())
             }
             EntryKind::Link(target) => {
-                if self.children.try_read().unwrap().contains_key(entry_name) {
+                if self.children.contains_key(entry_name) {
                     return Err(IncoherentStructure(format!(
                         "Adding {}, cannot add a link when one already exists",
                         entry.path()
                     ))
                     .into());
                 }
-                self.children.try_write().unwrap().insert(
+                self.children.insert(
                     entry_name.into(),
                     Entry::new_link(
                         entry_name.into(),
@@ -270,10 +265,10 @@ fn set_idx(
     idx: &mut impl Iterator<Item = u32>,
     parent_idx: Option<jbk::EntryIdx>,
 ) {
-    for child in parent_dir.children.try_write().unwrap().values_mut() {
+    for child in parent_dir.children.values_mut() {
         child.set_idx(jbk::EntryIdx::from(idx.next().unwrap()), parent_idx);
     }
-    for child in parent_dir.children.try_write().unwrap().values_mut() {
+    for child in parent_dir.children.values_mut() {
         if let Kind::Dir(d) = &mut child.kind {
             set_idx(d, idx, child.idx);
         }
@@ -281,10 +276,10 @@ fn set_idx(
 }
 
 fn flatten(entry: &mut DirEntry, res: &mut Vec<JbkEntry>, schema: &ArxSchema) {
-    for child in entry.children.try_write().unwrap().values_mut() {
+    for child in entry.children.values_mut() {
         res.push(to_basic_entry(child, schema));
     }
-    for child in entry.children.try_write().unwrap().values_mut() {
+    for child in entry.children.values_mut() {
         if let Kind::Dir(d) = &mut child.kind {
             flatten(d, res, schema);
         }

--- a/libarx/src/create/mut_entry_store.rs
+++ b/libarx/src/create/mut_entry_store.rs
@@ -1,4 +1,4 @@
-use super::entry_store_creator::{to_basic_entry, ArxSchema, JbkEntry};
+use super::entry_store_creator::{to_basic_entry, JbkEntry};
 use crate::IncoherentStructure;
 use std::collections::{BTreeMap, VecDeque};
 
@@ -280,7 +280,7 @@ fn set_idx(parent_dir: &mut DirEntry, idx: &mut impl Iterator<Item = u32>) {
     }
 }
 
-fn flatten(entry: &mut DirEntry, res: &mut Vec<JbkEntry>, schema: &ArxSchema) {
+fn flatten(entry: &mut DirEntry, res: &mut Vec<JbkEntry>) {
     let mut to_visit = VecDeque::new();
 
     for child in entry.children.values_mut() {
@@ -288,7 +288,7 @@ fn flatten(entry: &mut DirEntry, res: &mut Vec<JbkEntry>, schema: &ArxSchema) {
     }
 
     while let Some(entry) = to_visit.pop_front() {
-        res.push(to_basic_entry(entry, schema));
+        res.push(to_basic_entry(entry));
         if let Kind::Dir(d) = &mut entry.kind {
             for child in d.children.values_mut() {
                 to_visit.push_back(child);
@@ -297,12 +297,12 @@ fn flatten(entry: &mut DirEntry, res: &mut Vec<JbkEntry>, schema: &ArxSchema) {
     }
 }
 
-pub fn flat(mut tree: DirEntry, schema: &ArxSchema) -> Vec<JbkEntry> {
+pub fn flat(mut tree: DirEntry) -> Vec<JbkEntry> {
     let mut idx = std::ops::RangeFrom { start: 0 };
 
     set_idx(&mut tree, &mut idx);
 
     let mut res = Vec::with_capacity(idx.next().unwrap() as usize);
-    flatten(&mut tree, &mut res, schema);
+    flatten(&mut tree, &mut res);
     res
 }

--- a/libarx/src/create/mut_entry_store.rs
+++ b/libarx/src/create/mut_entry_store.rs
@@ -1,4 +1,4 @@
-use super::entry_store_creator::{to_basic_entry, JbkEntry};
+use super::entry_store_creator::JbkEntry;
 use crate::IncoherentStructure;
 use std::collections::{BTreeMap, VecDeque};
 
@@ -288,7 +288,7 @@ fn flatten(entry: &mut DirEntry, res: &mut Vec<JbkEntry>) {
     }
 
     while let Some(entry) = to_visit.pop_front() {
-        res.push(to_basic_entry(entry));
+        res.push(JbkEntry::new(entry));
         if let Kind::Dir(d) = &mut entry.kind {
             for child in d.children.values_mut() {
                 to_visit.push_back(child);

--- a/libarx/src/create/mut_entry_store.rs
+++ b/libarx/src/create/mut_entry_store.rs
@@ -98,7 +98,7 @@ type DirCache = BTreeMap<String, Entry>;
 /// This is needed as we may adde file without recursion, and so we need
 /// to find the parent of "foo/bar/baz.txt" ("foo/bar") when we add it.
 pub struct DirEntry {
-    children: DirCache,
+    pub children: DirCache,
 }
 
 impl DirEntry {
@@ -280,29 +280,41 @@ fn set_idx(parent_dir: &mut DirEntry, idx: &mut impl Iterator<Item = u32>) {
     }
 }
 
-fn flatten(entry: &mut DirEntry, res: &mut Vec<JbkEntry>) {
-    let mut to_visit = VecDeque::new();
+struct FlattenTree {
+    to_visit: VecDeque<Entry>,
+}
 
-    for child in entry.children.values_mut() {
-        to_visit.push_back(child);
-    }
+impl FlattenTree {
+    fn new(dir_entry: DirEntry) -> Self {
+        let mut to_visit = VecDeque::new();
 
-    while let Some(entry) = to_visit.pop_front() {
-        res.push(JbkEntry::new(entry));
-        if let Kind::Dir(d) = &mut entry.kind {
-            for child in d.children.values_mut() {
-                to_visit.push_back(child);
-            }
+        for child in dir_entry.children.into_values() {
+            to_visit.push_back(child);
         }
+        Self { to_visit }
     }
 }
 
-pub fn flat(mut tree: DirEntry) -> Vec<JbkEntry> {
+impl Iterator for FlattenTree {
+    type Item = JbkEntry;
+
+    fn next(&mut self) -> Option<JbkEntry> {
+        self.to_visit.pop_front().map(|e| {
+            let (jbk_entry, next_children) = JbkEntry::new(e);
+            if let Some(next_children) = next_children {
+                for child in next_children {
+                    self.to_visit.push_back(child);
+                }
+            }
+            jbk_entry
+        })
+    }
+}
+
+pub fn flat(mut tree: DirEntry) -> impl Iterator<Item = JbkEntry> {
     let mut idx = std::ops::RangeFrom { start: 0 };
 
     set_idx(&mut tree, &mut idx);
 
-    let mut res = Vec::with_capacity(idx.next().unwrap() as usize);
-    flatten(&mut tree, &mut res);
-    res
+    FlattenTree::new(tree)
 }


### PR DESCRIPTION
Adapt to new jbk api (https://github.com/jubako/jubako/pull/74)

We now have a two steps entry store creation:
- Update a tree
- Convert it to a iterator and give it to Jubako